### PR TITLE
feat(models): Epic C2 — OpenAI, Anthropic, Ollama model providers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@foxframework/core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@foxframework/core",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -1588,6 +1588,18 @@
     },
     "node_modules/@foxframework/db-sqlite": {
       "resolved": "packages/db-sqlite",
+      "link": true
+    },
+    "node_modules/@foxframework/model-anthropic": {
+      "resolved": "packages/model-anthropic",
+      "link": true
+    },
+    "node_modules/@foxframework/model-ollama": {
+      "resolved": "packages/model-ollama",
+      "link": true
+    },
+    "node_modules/@foxframework/model-openai": {
+      "resolved": "packages/model-openai",
       "link": true
     },
     "node_modules/@humanfs/core": {
@@ -10739,6 +10751,42 @@
         "better-sqlite3": {
           "optional": false
         }
+      }
+    },
+    "packages/model-anthropic": {
+      "name": "@foxframework/model-anthropic",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/jest": "^29.5.8",
+        "@types/node": "^20.10.4",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.1.1",
+        "typescript": "^5.3.2"
+      }
+    },
+    "packages/model-ollama": {
+      "name": "@foxframework/model-ollama",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/jest": "^29.5.8",
+        "@types/node": "^20.10.4",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.1.1",
+        "typescript": "^5.3.2"
+      }
+    },
+    "packages/model-openai": {
+      "name": "@foxframework/model-openai",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/jest": "^29.5.8",
+        "@types/node": "^20.10.4",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.1.1",
+        "typescript": "^5.3.2"
       }
     }
   }

--- a/packages/model-anthropic/__tests__/anthropic.test.ts
+++ b/packages/model-anthropic/__tests__/anthropic.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview Epic C2 — Anthropic provider test suite
+ */
+
+import { AnthropicProvider } from '../src/anthropic.provider';
+import type { ModelMessage } from '../src/types';
+
+const MESSAGES: ModelMessage[] = [
+  { role: 'system', content: 'You are helpful.' },
+  { role: 'user', content: 'Hello' },
+];
+
+function mockFetch(body: unknown, status = 200) {
+  return jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+    ok: status < 400,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    body: null,
+  } as any);
+}
+
+function anthropicResponse(text: string, toolUse?: any[]) {
+  const content: any[] = [{ type: 'text', text }];
+  if (toolUse) content.push(...toolUse);
+  return {
+    content,
+    stop_reason: toolUse ? 'tool_use' : 'end_turn',
+    usage: { input_tokens: 10, output_tokens: 5 },
+  };
+}
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('AnthropicProvider', () => {
+  it('uses default model', () => {
+    const p = new AnthropicProvider({ apiKey: 'test' });
+    expect(p.name).toBe('anthropic');
+  });
+
+  it('calls /messages and returns parsed response', async () => {
+    const spy = mockFetch(anthropicResponse('Hi there!'));
+    const provider = new AnthropicProvider({ apiKey: 'sk-ant-test' });
+    const result = await provider.complete(MESSAGES);
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('/messages'),
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(result.content).toBe('Hi there!');
+    expect(result.finishReason).toBe('stop');
+    expect(result.usage?.totalTokens).toBe(15);
+  });
+
+  it('sets x-api-key header', async () => {
+    const spy = mockFetch(anthropicResponse('ok'));
+    const provider = new AnthropicProvider({ apiKey: 'ant-secret' });
+    await provider.complete(MESSAGES);
+    const headers = (spy.mock.calls[0][1] as any).headers;
+    expect(headers['x-api-key']).toBe('ant-secret');
+  });
+
+  it('sets anthropic-version header', async () => {
+    const spy = mockFetch(anthropicResponse('ok'));
+    const provider = new AnthropicProvider({ apiKey: 'k', apiVersion: '2024-01-01' });
+    await provider.complete(MESSAGES);
+    const headers = (spy.mock.calls[0][1] as any).headers;
+    expect(headers['anthropic-version']).toBe('2024-01-01');
+  });
+
+  it('strips system messages from messages array and sends as system field', async () => {
+    const spy = mockFetch(anthropicResponse('ok'));
+    const provider = new AnthropicProvider({ apiKey: 'k' });
+    await provider.complete(MESSAGES);
+    const body = JSON.parse((spy.mock.calls[0][1] as any).body);
+    expect(body.system).toBe('You are helpful.');
+    expect(body.messages.every((m: any) => m.role !== 'system')).toBe(true);
+  });
+
+  it('parses tool_use blocks', async () => {
+    const toolUse = [{ type: 'tool_use', id: 'tu_1', name: 'search', input: { q: 'fox' } }];
+    mockFetch(anthropicResponse('', toolUse));
+    const provider = new AnthropicProvider({ apiKey: 'k' });
+    const result = await provider.complete(MESSAGES);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls![0].function.name).toBe('search');
+    expect(result.finishReason).toBe('tool_calls');
+  });
+
+  it('sends temperature option', async () => {
+    const spy = mockFetch(anthropicResponse('ok'));
+    const provider = new AnthropicProvider({ apiKey: 'k' });
+    await provider.complete(MESSAGES, { temperature: 0.3 });
+    const body = JSON.parse((spy.mock.calls[0][1] as any).body);
+    expect(body.temperature).toBe(0.3);
+  });
+
+  it('throws on HTTP error', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false, status: 429, text: async () => 'Rate limit', body: null,
+    } as any);
+    const provider = new AnthropicProvider({ apiKey: 'k' });
+    await expect(provider.complete(MESSAGES)).rejects.toThrow('429');
+  });
+});

--- a/packages/model-anthropic/jest.config.ts
+++ b/packages/model-anthropic/jest.config.ts
@@ -1,0 +1,3 @@
+import type { Config } from 'jest';
+const config: Config = { preset: 'ts-jest', testEnvironment: 'node', roots: ['<rootDir>/__tests__'], transform: { '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }] } };
+export default config;

--- a/packages/model-anthropic/package.json
+++ b/packages/model-anthropic/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@foxframework/model-anthropic",
+  "version": "1.0.0",
+  "description": "Anthropic (Claude) model provider for Fox Framework agents — native fetch, no SDK",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist/**/*", "package.json"],
+  "publishConfig": { "access": "public" },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "jest --config jest.config.ts --detectOpenHandles --forceExit"
+  },
+  "keywords": ["fox-framework", "anthropic", "claude", "llm", "agents"],
+  "author": "Luis Navarro Carter",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/jest": "^29.5.8",
+    "@types/node": "^20.10.4",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.3.2"
+  }
+}

--- a/packages/model-anthropic/src/anthropic.provider.ts
+++ b/packages/model-anthropic/src/anthropic.provider.ts
@@ -1,0 +1,181 @@
+/**
+ * @fileoverview Anthropic (Claude) model provider — native fetch, no SDK
+ * @module @foxframework/model-anthropic
+ *
+ * Supports:
+ *  - Messages API (claude-3-5-sonnet, claude-3-opus, …)
+ *  - Streaming via Server-Sent Events
+ *  - Tool use (function calling)
+ */
+
+import type {
+  IModelProvider,
+  ModelMessage,
+  ModelOptions,
+  ModelResponse,
+  StreamChunk,
+  ToolCall,
+} from './types';
+
+export interface AnthropicProviderConfig {
+  /** Anthropic API key */
+  apiKey: string;
+  /** Model ID (default: 'claude-3-5-sonnet-20241022') */
+  model?: string;
+  /** Base URL (default: 'https://api.anthropic.com/v1') */
+  baseUrl?: string;
+  /** Anthropic API version header (default: '2023-06-01') */
+  apiVersion?: string;
+  /** Default request timeout ms (default: 60_000) */
+  timeoutMs?: number;
+}
+
+export class AnthropicProvider implements IModelProvider {
+  readonly name = 'anthropic';
+  private readonly _config: Required<AnthropicProviderConfig>;
+
+  constructor(config: AnthropicProviderConfig) {
+    this._config = {
+      model: 'claude-3-5-sonnet-20241022',
+      baseUrl: 'https://api.anthropic.com/v1',
+      apiVersion: '2023-06-01',
+      timeoutMs: 60_000,
+      ...config,
+    };
+  }
+
+  async complete(messages: ModelMessage[], options: ModelOptions = {}): Promise<ModelResponse> {
+    const { system, anthropicMessages } = this._splitMessages(messages);
+    const body = this._buildBody(anthropicMessages, system, options, false);
+    const res = await this._fetch('/messages', body);
+    const json = await res.json() as any;
+    return this._parseResponse(json);
+  }
+
+  async *stream(messages: ModelMessage[], options: ModelOptions = {}): AsyncIterable<StreamChunk> {
+    const { system, anthropicMessages } = this._splitMessages(messages);
+    const body = this._buildBody(anthropicMessages, system, options, true);
+    const res = await this._fetch('/messages', body);
+
+    if (!res.body) throw new Error('[AnthropicProvider] No response body for streaming');
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      let eventType = '';
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('event: ')) { eventType = trimmed.slice(7); continue; }
+        if (!trimmed.startsWith('data: ')) continue;
+        try {
+          const data = JSON.parse(trimmed.slice(6)) as any;
+          if (eventType === 'content_block_delta') {
+            yield { delta: data.delta?.text ?? '', done: false };
+          } else if (eventType === 'message_stop') {
+            yield { delta: '', done: true };
+          }
+        } catch { /* skip */ }
+      }
+    }
+    yield { delta: '', done: true };
+  }
+
+  // ── private helpers ─────────────────────────────────────────────────────────
+
+  private _splitMessages(messages: ModelMessage[]) {
+    const systemMessages = messages.filter(m => m.role === 'system');
+    const system = systemMessages.map(m => m.content).join('\n');
+    const anthropicMessages = messages
+      .filter(m => m.role !== 'system')
+      .map(m => ({
+        role: m.role === 'tool' ? 'user' : m.role,
+        content: m.role === 'tool'
+          ? [{ type: 'tool_result', tool_use_id: m.toolCallId, content: m.content }]
+          : m.content,
+      }));
+    return { system, anthropicMessages };
+  }
+
+  private _buildBody(
+    messages: any[],
+    system: string,
+    options: ModelOptions,
+    stream: boolean,
+  ): Record<string, unknown> {
+    const body: Record<string, unknown> = {
+      model: this._config.model,
+      messages,
+      max_tokens: options.maxTokens ?? 4096,
+      stream,
+    };
+    if (system) body.system = system;
+    if (options.temperature !== undefined) body.temperature = options.temperature;
+    if (options.topP !== undefined) body.top_p = options.topP;
+    if (options.stopSequences?.length) body.stop_sequences = options.stopSequences;
+    return body;
+  }
+
+  private async _fetch(path: string, body: Record<string, unknown>): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this._config.timeoutMs);
+
+    try {
+      const res = await fetch(`${this._config.baseUrl}${path}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': this._config.apiKey,
+          'anthropic-version': this._config.apiVersion,
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        const err = await res.text();
+        throw new Error(`[AnthropicProvider] HTTP ${res.status}: ${err}`);
+      }
+      return res;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private _parseResponse(json: any): ModelResponse {
+    const content = json.content ?? [];
+    const textBlock = content.find((b: any) => b.type === 'text');
+    const toolUseBlocks = content.filter((b: any) => b.type === 'tool_use');
+
+    const toolCalls: ToolCall[] | undefined = toolUseBlocks.length
+      ? toolUseBlocks.map((b: any) => ({
+          id: b.id,
+          type: 'function' as const,
+          function: { name: b.name, arguments: JSON.stringify(b.input ?? {}) },
+        }))
+      : undefined;
+
+    return {
+      content: textBlock?.text ?? '',
+      toolCalls,
+      usage: json.usage
+        ? {
+            promptTokens: json.usage.input_tokens,
+            completionTokens: json.usage.output_tokens,
+            totalTokens: json.usage.input_tokens + json.usage.output_tokens,
+          }
+        : undefined,
+      finishReason: json.stop_reason === 'end_turn'
+        ? 'stop'
+        : json.stop_reason === 'tool_use' ? 'tool_calls' : json.stop_reason,
+    };
+  }
+}

--- a/packages/model-anthropic/src/index.ts
+++ b/packages/model-anthropic/src/index.ts
@@ -1,0 +1,3 @@
+export type { IModelProvider, ModelMessage, ModelOptions, ModelResponse, StreamChunk, ToolCall } from './types';
+export { AnthropicProvider } from './anthropic.provider';
+export type { AnthropicProviderConfig } from './anthropic.provider';

--- a/packages/model-anthropic/src/types.ts
+++ b/packages/model-anthropic/src/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Re-export of agent interfaces used by model providers.
+ * In a real installation these come from @foxframework/core.
+ * We duplicate the minimal subset here to keep the package dependency-free.
+ */
+
+export interface ModelMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string;
+  toolCallId?: string;
+  toolCalls?: ToolCall[];
+}
+
+export interface ToolCall {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
+}
+
+export interface ModelOptions {
+  temperature?: number;
+  maxTokens?: number;
+  topP?: number;
+  stopSequences?: string[];
+  stream?: boolean;
+}
+
+export interface ModelResponse {
+  content: string;
+  toolCalls?: ToolCall[];
+  usage?: { promptTokens: number; completionTokens: number; totalTokens: number };
+  finishReason?: 'stop' | 'length' | 'tool_calls' | 'content_filter';
+}
+
+export interface StreamChunk {
+  delta: string;
+  done: boolean;
+  toolCalls?: ToolCall[];
+}
+
+export interface IModelProvider {
+  readonly name: string;
+  complete(messages: ModelMessage[], options?: ModelOptions): Promise<ModelResponse>;
+  stream(messages: ModelMessage[], options?: ModelOptions): AsyncIterable<StreamChunk>;
+}

--- a/packages/model-anthropic/tsconfig.build.json
+++ b/packages/model-anthropic/tsconfig.build.json
@@ -1,0 +1,1 @@
+{"extends":"../../tsconfig.json","compilerOptions":{"rootDir":"./src","outDir":"./dist","declaration":true,"declarationMap":true,"paths":{}},"include":["src/**/*"],"exclude":["node_modules","dist","**/*.test.ts"]}

--- a/packages/model-anthropic/tsconfig.json
+++ b/packages/model-anthropic/tsconfig.json
@@ -1,0 +1,1 @@
+{"extends":"../../tsconfig.json","compilerOptions":{"rootDir":".","outDir":"./dist-test","paths":{}},"include":["src/**/*","__tests__/**/*"],"exclude":["node_modules","dist"]}

--- a/packages/model-ollama/__tests__/ollama.test.ts
+++ b/packages/model-ollama/__tests__/ollama.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @fileoverview Epic C2 — Ollama provider test suite
+ */
+
+import { OllamaProvider } from '../src/ollama.provider';
+import type { ModelMessage } from '../src/types';
+
+const MESSAGES: ModelMessage[] = [
+  { role: 'user', content: 'Hello' },
+];
+
+function mockFetch(body: unknown, status = 200) {
+  return jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+    ok: status < 400,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    body: null,
+  } as any);
+}
+
+function ollamaResponse(content: string, toolCalls?: any[]) {
+  return {
+    message: { role: 'assistant', content, tool_calls: toolCalls },
+    done: true,
+    prompt_eval_count: 8,
+    eval_count: 4,
+  };
+}
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('OllamaProvider', () => {
+  it('uses default model llama3', () => {
+    const p = new OllamaProvider();
+    expect(p.name).toBe('ollama');
+  });
+
+  it('calls /api/chat and returns parsed response', async () => {
+    const spy = mockFetch(ollamaResponse('Hi from Ollama!'));
+    const provider = new OllamaProvider();
+    const result = await provider.complete(MESSAGES);
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('/api/chat'),
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(result.content).toBe('Hi from Ollama!');
+    expect(result.finishReason).toBe('stop');
+    expect(result.usage?.totalTokens).toBe(12);
+  });
+
+  it('sends model name in body', async () => {
+    const spy = mockFetch(ollamaResponse('ok'));
+    const provider = new OllamaProvider({ model: 'mistral' });
+    await provider.complete(MESSAGES);
+    const body = JSON.parse((spy.mock.calls[0][1] as any).body);
+    expect(body.model).toBe('mistral');
+  });
+
+  it('sends temperature option as ollama options.temperature', async () => {
+    const spy = mockFetch(ollamaResponse('ok'));
+    const provider = new OllamaProvider();
+    await provider.complete(MESSAGES, { temperature: 0.7 });
+    const body = JSON.parse((spy.mock.calls[0][1] as any).body);
+    expect(body.options?.temperature).toBe(0.7);
+  });
+
+  it('sends maxTokens as num_predict', async () => {
+    const spy = mockFetch(ollamaResponse('ok'));
+    const provider = new OllamaProvider();
+    await provider.complete(MESSAGES, { maxTokens: 512 });
+    const body = JSON.parse((spy.mock.calls[0][1] as any).body);
+    expect(body.options?.num_predict).toBe(512);
+  });
+
+  it('uses custom base URL', async () => {
+    const spy = mockFetch(ollamaResponse('ok'));
+    const provider = new OllamaProvider({ baseUrl: 'http://gpu-server:11434' });
+    await provider.complete(MESSAGES);
+    expect(spy.mock.calls[0][0]).toContain('gpu-server:11434');
+  });
+
+  it('parses tool calls', async () => {
+    const toolCalls = [{ id: 'tc_1', function: { name: 'calculator', arguments: '{"expr":"2+2"}' } }];
+    mockFetch(ollamaResponse('', toolCalls));
+    const provider = new OllamaProvider();
+    const result = await provider.complete(MESSAGES);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls![0].function.name).toBe('calculator');
+  });
+
+  it('handles missing usage gracefully', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true, status: 200,
+      json: async () => ({ message: { content: 'hi' }, done: true }),
+      body: null,
+    } as any);
+    const provider = new OllamaProvider();
+    const result = await provider.complete(MESSAGES);
+    expect(result.usage).toBeUndefined();
+  });
+
+  it('throws on HTTP error', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false, status: 500, text: async () => 'Server error', body: null,
+    } as any);
+    const provider = new OllamaProvider();
+    await expect(provider.complete(MESSAGES)).rejects.toThrow('500');
+  });
+
+  it('stream() yields chunks', async () => {
+    const ndjson = [
+      JSON.stringify({ message: { content: 'chunk1' }, done: false }),
+      JSON.stringify({ message: { content: ' chunk2' }, done: true }),
+    ].join('\n');
+
+    const encoder = new TextEncoder();
+    const encoded = encoder.encode(ndjson);
+    let pos = 0;
+    const mockReader = {
+      read: jest.fn(async () => {
+        if (pos >= encoded.length) return { done: true, value: undefined };
+        const chunk = encoded.slice(pos, pos + 30);
+        pos += 30;
+        return { done: false, value: chunk };
+      }),
+    };
+
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true, status: 200,
+      body: { getReader: () => mockReader },
+    } as any);
+
+    const provider = new OllamaProvider();
+    const chunks: string[] = [];
+    for await (const c of provider.stream(MESSAGES)) {
+      if (c.delta) chunks.push(c.delta);
+    }
+    expect(chunks.join('')).toContain('chunk1');
+  });
+});

--- a/packages/model-ollama/jest.config.ts
+++ b/packages/model-ollama/jest.config.ts
@@ -1,0 +1,3 @@
+import type { Config } from 'jest';
+const config: Config = { preset: 'ts-jest', testEnvironment: 'node', roots: ['<rootDir>/__tests__'], transform: { '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }] } };
+export default config;

--- a/packages/model-ollama/package.json
+++ b/packages/model-ollama/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@foxframework/model-ollama",
+  "version": "1.0.0",
+  "description": "Ollama local model provider for Fox Framework agents — native fetch, no SDK",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist/**/*", "package.json"],
+  "publishConfig": { "access": "public" },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "jest --config jest.config.ts --detectOpenHandles --forceExit"
+  },
+  "keywords": ["fox-framework", "ollama", "local-llm", "agents"],
+  "author": "Luis Navarro Carter",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/jest": "^29.5.8",
+    "@types/node": "^20.10.4",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.3.2"
+  }
+}

--- a/packages/model-ollama/src/index.ts
+++ b/packages/model-ollama/src/index.ts
@@ -1,0 +1,3 @@
+export type { IModelProvider, ModelMessage, ModelOptions, ModelResponse, StreamChunk, ToolCall } from './types';
+export { OllamaProvider } from './ollama.provider';
+export type { OllamaProviderConfig } from './ollama.provider';

--- a/packages/model-ollama/src/ollama.provider.ts
+++ b/packages/model-ollama/src/ollama.provider.ts
@@ -1,0 +1,168 @@
+/**
+ * @fileoverview Ollama local model provider — native fetch, no SDK
+ * @module @foxframework/model-ollama
+ *
+ * Supports:
+ *  - /api/chat endpoint (llama3, mistral, codellama, …)
+ *  - Streaming via newline-delimited JSON
+ *  - Tool calling (for models that support it)
+ *  - Keep-alive control
+ */
+
+import type {
+  IModelProvider,
+  ModelMessage,
+  ModelOptions,
+  ModelResponse,
+  StreamChunk,
+  ToolCall,
+} from './types';
+
+export interface OllamaProviderConfig {
+  /** Model name (default: 'llama3') */
+  model?: string;
+  /** Ollama base URL (default: 'http://localhost:11434') */
+  baseUrl?: string;
+  /** Keep model loaded for N seconds after request (default: 300) */
+  keepAlive?: number;
+  /** Request timeout ms (default: 120_000) */
+  timeoutMs?: number;
+}
+
+export class OllamaProvider implements IModelProvider {
+  readonly name = 'ollama';
+  private readonly _config: Required<OllamaProviderConfig>;
+
+  constructor(config: OllamaProviderConfig = {}) {
+    this._config = {
+      model: 'llama3',
+      baseUrl: 'http://localhost:11434',
+      keepAlive: 300,
+      timeoutMs: 120_000,
+      ...config,
+    };
+  }
+
+  async complete(messages: ModelMessage[], options: ModelOptions = {}): Promise<ModelResponse> {
+    const body = this._buildBody(messages, options, false);
+    const res = await this._fetch('/api/chat', body);
+    const json = await res.json() as any;
+    return this._parseResponse(json);
+  }
+
+  async *stream(messages: ModelMessage[], options: ModelOptions = {}): AsyncIterable<StreamChunk> {
+    const body = this._buildBody(messages, options, true);
+    const res = await this._fetch('/api/chat', body);
+
+    if (!res.body) throw new Error('[OllamaProvider] No response body for streaming');
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const chunk = JSON.parse(trimmed) as any;
+          yield {
+            delta: chunk.message?.content ?? '',
+            done: chunk.done ?? false,
+          };
+        } catch { /* skip */ }
+      }
+    }
+
+    yield { delta: '', done: true };
+  }
+
+  // ── private helpers ─────────────────────────────────────────────────────────
+
+  private _buildBody(
+    messages: ModelMessage[],
+    options: ModelOptions,
+    stream: boolean,
+  ): Record<string, unknown> {
+    const ollamaMessages = messages.map(m => ({
+      role: m.role === 'tool' ? 'tool' : m.role,
+      content: m.content,
+      ...(m.toolCallId ? { tool_call_id: m.toolCallId } : {}),
+      ...(m.toolCalls ? { tool_calls: m.toolCalls } : {}),
+    }));
+
+    const body: Record<string, unknown> = {
+      model: this._config.model,
+      messages: ollamaMessages,
+      stream,
+      keep_alive: this._config.keepAlive,
+    };
+
+    const ollama_options: Record<string, unknown> = {};
+    if (options.temperature !== undefined) ollama_options.temperature = options.temperature;
+    if (options.topP !== undefined) ollama_options.top_p = options.topP;
+    if (options.maxTokens !== undefined) ollama_options.num_predict = options.maxTokens;
+    if (options.stopSequences?.length) ollama_options.stop = options.stopSequences;
+    if (Object.keys(ollama_options).length) body.options = ollama_options;
+
+    return body;
+  }
+
+  private async _fetch(path: string, body: Record<string, unknown>): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this._config.timeoutMs);
+
+    try {
+      const res = await fetch(`${this._config.baseUrl}${path}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        const err = await res.text();
+        throw new Error(`[OllamaProvider] HTTP ${res.status}: ${err}`);
+      }
+      return res;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private _parseResponse(json: any): ModelResponse {
+    const message = json.message;
+    const toolCalls: ToolCall[] | undefined = message?.tool_calls?.length
+      ? message.tool_calls.map((tc: any) => ({
+          id: tc.id ?? `tc_${Date.now()}`,
+          type: 'function' as const,
+          function: {
+            name: tc.function?.name ?? tc.name,
+            arguments: typeof tc.function?.arguments === 'string'
+              ? tc.function.arguments
+              : JSON.stringify(tc.function?.arguments ?? {}),
+          },
+        }))
+      : undefined;
+
+    return {
+      content: message?.content ?? '',
+      toolCalls,
+      usage: json.prompt_eval_count != null
+        ? {
+            promptTokens: json.prompt_eval_count,
+            completionTokens: json.eval_count ?? 0,
+            totalTokens: (json.prompt_eval_count ?? 0) + (json.eval_count ?? 0),
+          }
+        : undefined,
+      finishReason: json.done ? 'stop' : undefined,
+    };
+  }
+}

--- a/packages/model-ollama/src/types.ts
+++ b/packages/model-ollama/src/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Re-export of agent interfaces used by model providers.
+ * In a real installation these come from @foxframework/core.
+ * We duplicate the minimal subset here to keep the package dependency-free.
+ */
+
+export interface ModelMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string;
+  toolCallId?: string;
+  toolCalls?: ToolCall[];
+}
+
+export interface ToolCall {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
+}
+
+export interface ModelOptions {
+  temperature?: number;
+  maxTokens?: number;
+  topP?: number;
+  stopSequences?: string[];
+  stream?: boolean;
+}
+
+export interface ModelResponse {
+  content: string;
+  toolCalls?: ToolCall[];
+  usage?: { promptTokens: number; completionTokens: number; totalTokens: number };
+  finishReason?: 'stop' | 'length' | 'tool_calls' | 'content_filter';
+}
+
+export interface StreamChunk {
+  delta: string;
+  done: boolean;
+  toolCalls?: ToolCall[];
+}
+
+export interface IModelProvider {
+  readonly name: string;
+  complete(messages: ModelMessage[], options?: ModelOptions): Promise<ModelResponse>;
+  stream(messages: ModelMessage[], options?: ModelOptions): AsyncIterable<StreamChunk>;
+}

--- a/packages/model-ollama/tsconfig.build.json
+++ b/packages/model-ollama/tsconfig.build.json
@@ -1,0 +1,1 @@
+{"extends":"../../tsconfig.json","compilerOptions":{"rootDir":"./src","outDir":"./dist","declaration":true,"declarationMap":true,"paths":{}},"include":["src/**/*"],"exclude":["node_modules","dist","**/*.test.ts"]}

--- a/packages/model-ollama/tsconfig.json
+++ b/packages/model-ollama/tsconfig.json
@@ -1,0 +1,1 @@
+{"extends":"../../tsconfig.json","compilerOptions":{"rootDir":".","outDir":"./dist-test","paths":{}},"include":["src/**/*","__tests__/**/*"],"exclude":["node_modules","dist"]}

--- a/packages/model-openai/__tests__/openai.test.ts
+++ b/packages/model-openai/__tests__/openai.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @fileoverview Epic C2 — OpenAI provider test suite
+ * Uses fetch mock — no real HTTP calls
+ */
+
+import { OpenAIProvider } from '../src/openai.provider';
+import type { ModelMessage } from '../src/types';
+
+const MESSAGES: ModelMessage[] = [
+  { role: 'system', content: 'You are helpful.' },
+  { role: 'user', content: 'Hello' },
+];
+
+function mockFetch(body: unknown, status = 200) {
+  return jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+    ok: status < 400,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    body: null,
+  } as any);
+}
+
+function openAIResponse(content: string, toolCalls?: any[]) {
+  return {
+    choices: [{
+      message: { role: 'assistant', content, tool_calls: toolCalls },
+      finish_reason: toolCalls ? 'tool_calls' : 'stop',
+    }],
+    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+  };
+}
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('OpenAIProvider', () => {
+  it('uses default model gpt-4o', () => {
+    const p = new OpenAIProvider({ apiKey: 'test' });
+    expect(p.name).toBe('openai');
+  });
+
+  it('calls /chat/completions and returns parsed response', async () => {
+    const spy = mockFetch(openAIResponse('Hello there!'));
+    const provider = new OpenAIProvider({ apiKey: 'sk-test' });
+    const result = await provider.complete(MESSAGES);
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('/chat/completions'),
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(result.content).toBe('Hello there!');
+    expect(result.finishReason).toBe('stop');
+    expect(result.usage?.totalTokens).toBe(15);
+  });
+
+  it('parses tool calls', async () => {
+    const tc = [{ id: 'tc_1', type: 'function', function: { name: 'search', arguments: '{"q":"fox"}' } }];
+    mockFetch(openAIResponse('', tc));
+    const provider = new OpenAIProvider({ apiKey: 'sk-test' });
+    const result = await provider.complete(MESSAGES);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls![0].function.name).toBe('search');
+    expect(result.finishReason).toBe('tool_calls');
+  });
+
+  it('includes Authorization header', async () => {
+    const spy = mockFetch(openAIResponse('hi'));
+    const provider = new OpenAIProvider({ apiKey: 'sk-secret' });
+    await provider.complete(MESSAGES);
+    const headers = (spy.mock.calls[0][1] as any).headers;
+    expect(headers['Authorization']).toBe('Bearer sk-secret');
+  });
+
+  it('includes Organization header when set', async () => {
+    const spy = mockFetch(openAIResponse('hi'));
+    const provider = new OpenAIProvider({ apiKey: 'sk-test', organization: 'org-123' });
+    await provider.complete(MESSAGES);
+    const headers = (spy.mock.calls[0][1] as any).headers;
+    expect(headers['OpenAI-Organization']).toBe('org-123');
+  });
+
+  it('sends temperature and maxTokens', async () => {
+    const spy = mockFetch(openAIResponse('ok'));
+    const provider = new OpenAIProvider({ apiKey: 'sk-test' });
+    await provider.complete(MESSAGES, { temperature: 0.5, maxTokens: 100 });
+    const body = JSON.parse((spy.mock.calls[0][1] as any).body);
+    expect(body.temperature).toBe(0.5);
+    expect(body.max_tokens).toBe(100);
+  });
+
+  it('uses custom base URL', async () => {
+    const spy = mockFetch(openAIResponse('ok'));
+    const provider = new OpenAIProvider({ apiKey: 'sk-test', baseUrl: 'https://my-proxy/v1' });
+    await provider.complete(MESSAGES);
+    expect(spy.mock.calls[0][0]).toContain('https://my-proxy/v1');
+  });
+
+  it('throws on HTTP error', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false, status: 401, text: async () => 'Unauthorized', body: null,
+    } as any);
+    const provider = new OpenAIProvider({ apiKey: 'bad' });
+    await expect(provider.complete(MESSAGES)).rejects.toThrow('401');
+  });
+
+  it('stream() yields chunks', async () => {
+    const sseBody = [
+      'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}',
+      'data: {"choices":[{"delta":{"content":" world"},"finish_reason":"stop"}]}',
+      'data: [DONE]',
+    ].join('\n');
+
+    const encoder = new TextEncoder();
+    const encoded = encoder.encode(sseBody);
+    let pos = 0;
+    const mockReader = {
+      read: jest.fn(async () => {
+        if (pos >= encoded.length) return { done: true, value: undefined };
+        const chunk = encoded.slice(pos, pos + 40);
+        pos += 40;
+        return { done: false, value: chunk };
+      }),
+    };
+
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true, status: 200,
+      body: { getReader: () => mockReader },
+    } as any);
+
+    const provider = new OpenAIProvider({ apiKey: 'sk-test' });
+    const chunks: string[] = [];
+    for await (const chunk of provider.stream(MESSAGES)) {
+      if (chunk.delta) chunks.push(chunk.delta);
+    }
+    expect(chunks.join('')).toContain('Hello');
+  });
+});

--- a/packages/model-openai/jest.config.ts
+++ b/packages/model-openai/jest.config.ts
@@ -1,0 +1,3 @@
+import type { Config } from 'jest';
+const config: Config = { preset: 'ts-jest', testEnvironment: 'node', roots: ['<rootDir>/__tests__'], transform: { '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }] } };
+export default config;

--- a/packages/model-openai/package.json
+++ b/packages/model-openai/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@foxframework/model-openai",
+  "version": "1.0.0",
+  "description": "OpenAI model provider for Fox Framework agents — native fetch, no SDK",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist/**/*", "package.json"],
+  "publishConfig": { "access": "public" },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "jest --config jest.config.ts --detectOpenHandles --forceExit"
+  },
+  "keywords": ["fox-framework", "openai", "llm", "agents"],
+  "author": "Luis Navarro Carter",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/jest": "^29.5.8",
+    "@types/node": "^20.10.4",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.3.2"
+  }
+}

--- a/packages/model-openai/src/index.ts
+++ b/packages/model-openai/src/index.ts
@@ -1,0 +1,3 @@
+export type { IModelProvider, ModelMessage, ModelOptions, ModelResponse, StreamChunk, ToolCall } from './types';
+export { OpenAIProvider } from './openai.provider';
+export type { OpenAIProviderConfig } from './openai.provider';

--- a/packages/model-openai/src/openai.provider.ts
+++ b/packages/model-openai/src/openai.provider.ts
@@ -1,0 +1,168 @@
+/**
+ * @fileoverview OpenAI model provider — native fetch, no SDK
+ * @module @foxframework/model-openai
+ *
+ * Supports:
+ *  - Chat completions (gpt-4o, gpt-4-turbo, gpt-3.5-turbo, …)
+ *  - Streaming via Server-Sent Events
+ *  - Function/tool calling
+ *  - Configurable base URL (Azure OpenAI compatible)
+ */
+
+import type {
+  IModelProvider,
+  ModelMessage,
+  ModelOptions,
+  ModelResponse,
+  StreamChunk,
+  ToolCall,
+} from './types';
+
+export interface OpenAIProviderConfig {
+  /** OpenAI API key */
+  apiKey: string;
+  /** Model ID (default: 'gpt-4o') */
+  model?: string;
+  /** Base URL (default: 'https://api.openai.com/v1') */
+  baseUrl?: string;
+  /** Organisation ID */
+  organization?: string;
+  /** Default request timeout ms (default: 30_000) */
+  timeoutMs?: number;
+}
+
+export class OpenAIProvider implements IModelProvider {
+  readonly name = 'openai';
+  private readonly _config: Required<OpenAIProviderConfig>;
+
+  constructor(config: OpenAIProviderConfig) {
+    this._config = {
+      model: 'gpt-4o',
+      baseUrl: 'https://api.openai.com/v1',
+      organization: '',
+      timeoutMs: 30_000,
+      ...config,
+    };
+  }
+
+  async complete(messages: ModelMessage[], options: ModelOptions = {}): Promise<ModelResponse> {
+    const body = this._buildBody(messages, options, false);
+    const res = await this._fetch('/chat/completions', body, options);
+    const json = await res.json() as any;
+    return this._parseResponse(json);
+  }
+
+  async *stream(messages: ModelMessage[], options: ModelOptions = {}): AsyncIterable<StreamChunk> {
+    const body = this._buildBody(messages, options, true);
+    const res = await this._fetch('/chat/completions', body, options);
+
+    if (!res.body) throw new Error('[OpenAIProvider] No response body for streaming');
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed === 'data: [DONE]') continue;
+        if (!trimmed.startsWith('data: ')) continue;
+
+        try {
+          const chunk = JSON.parse(trimmed.slice(6)) as any;
+          const delta = chunk.choices?.[0]?.delta;
+          const finishReason = chunk.choices?.[0]?.finish_reason;
+          yield {
+            delta: delta?.content ?? '',
+            done: finishReason === 'stop',
+            toolCalls: delta?.tool_calls,
+          };
+        } catch { /* skip malformed SSE chunk */ }
+      }
+    }
+
+    yield { delta: '', done: true };
+  }
+
+  // ── private helpers ─────────────────────────────────────────────────────────
+
+  private _buildBody(messages: ModelMessage[], options: ModelOptions, stream: boolean): Record<string, unknown> {
+    const body: Record<string, unknown> = {
+      model: this._config.model,
+      messages: messages.map(m => ({
+        role: m.role,
+        content: m.content,
+        ...(m.toolCallId ? { tool_call_id: m.toolCallId } : {}),
+        ...(m.toolCalls ? { tool_calls: m.toolCalls } : {}),
+      })),
+      stream,
+    };
+
+    if (options.temperature !== undefined) body.temperature = options.temperature;
+    if (options.maxTokens !== undefined) body.max_tokens = options.maxTokens;
+    if (options.topP !== undefined) body.top_p = options.topP;
+    if (options.stopSequences?.length) body.stop = options.stopSequences;
+
+    return body;
+  }
+
+  private async _fetch(path: string, body: Record<string, unknown>, _options: ModelOptions): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this._config.timeoutMs);
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${this._config.apiKey}`,
+    };
+    if (this._config.organization) {
+      headers['OpenAI-Organization'] = this._config.organization;
+    }
+
+    try {
+      const res = await fetch(`${this._config.baseUrl}${path}`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        const err = await res.text();
+        throw new Error(`[OpenAIProvider] HTTP ${res.status}: ${err}`);
+      }
+      return res;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private _parseResponse(json: any): ModelResponse {
+    const choice = json.choices?.[0];
+    const message = choice?.message;
+    const toolCalls: ToolCall[] | undefined = message?.tool_calls?.map((tc: any) => ({
+      id: tc.id,
+      type: 'function' as const,
+      function: { name: tc.function.name, arguments: tc.function.arguments },
+    }));
+
+    return {
+      content: message?.content ?? '',
+      toolCalls: toolCalls?.length ? toolCalls : undefined,
+      usage: json.usage
+        ? {
+            promptTokens: json.usage.prompt_tokens,
+            completionTokens: json.usage.completion_tokens,
+            totalTokens: json.usage.total_tokens,
+          }
+        : undefined,
+      finishReason: choice?.finish_reason as ModelResponse['finishReason'],
+    };
+  }
+}

--- a/packages/model-openai/src/types.ts
+++ b/packages/model-openai/src/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Re-export of agent interfaces used by model providers.
+ * In a real installation these come from @foxframework/core.
+ * We duplicate the minimal subset here to keep the package dependency-free.
+ */
+
+export interface ModelMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string;
+  toolCallId?: string;
+  toolCalls?: ToolCall[];
+}
+
+export interface ToolCall {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
+}
+
+export interface ModelOptions {
+  temperature?: number;
+  maxTokens?: number;
+  topP?: number;
+  stopSequences?: string[];
+  stream?: boolean;
+}
+
+export interface ModelResponse {
+  content: string;
+  toolCalls?: ToolCall[];
+  usage?: { promptTokens: number; completionTokens: number; totalTokens: number };
+  finishReason?: 'stop' | 'length' | 'tool_calls' | 'content_filter';
+}
+
+export interface StreamChunk {
+  delta: string;
+  done: boolean;
+  toolCalls?: ToolCall[];
+}
+
+export interface IModelProvider {
+  readonly name: string;
+  complete(messages: ModelMessage[], options?: ModelOptions): Promise<ModelResponse>;
+  stream(messages: ModelMessage[], options?: ModelOptions): AsyncIterable<StreamChunk>;
+}

--- a/packages/model-openai/tsconfig.build.json
+++ b/packages/model-openai/tsconfig.build.json
@@ -1,0 +1,1 @@
+{"extends":"../../tsconfig.json","compilerOptions":{"rootDir":"./src","outDir":"./dist","declaration":true,"declarationMap":true,"paths":{}},"include":["src/**/*"],"exclude":["node_modules","dist","**/*.test.ts"]}

--- a/packages/model-openai/tsconfig.json
+++ b/packages/model-openai/tsconfig.json
@@ -1,0 +1,1 @@
+{"extends":"../../tsconfig.json","compilerOptions":{"rootDir":".","outDir":"./dist-test","paths":{}},"include":["src/**/*","__tests__/**/*"],"exclude":["node_modules","dist"]}


### PR DESCRIPTION
## Summary

Three model provider packages, all using native \`fetch\` with zero vendor SDK dependencies:

| Package | Provider | Tests |
|---|---|---|
| \`@foxframework/model-openai\` | OpenAI Chat Completions (gpt-4o, …) | 9 |
| \`@foxframework/model-anthropic\` | Anthropic Messages API (claude-3-5-sonnet, …) | 8 |
| \`@foxframework/model-ollama\` | Ollama local models (llama3, mistral, …) | 10 |

### Features per provider
- **OpenAI**: tool calls, streaming (SSE), Organization header, custom baseUrl, temp/maxTokens/topP/stop
- **Anthropic**: tool_use blocks, streaming (SSE), system prompt extraction, anthropic-version header
- **Ollama**: keep_alive, streaming (ndjson), options passthrough (temperature → num_predict → top_p → stop), custom baseUrl

All implement the \`IModelProvider\` interface from \`tsfox/core/agents\`.

## Tests

27 passing (9+8+10), 0 TS errors, fetch mocked in all tests.