### PR TITLE
feat(agents): Epic D1 — Agent Tools Library (44 tests)

### DIFF
--- a/tsfox/core/agents/__tests__/epic-d1.test.ts
+++ b/tsfox/core/agents/__tests__/epic-d1.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Epic D1 — Agent Tools Library
+ * Tests for: HttpTool, FilesystemTool, CalculatorTool, JsonPathTool, SqlQueryTool, VectorSearchTool
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+
+import { HttpTool } from '../tools/http.tool';
+import { FilesystemTool, createFilesystemTool } from '../tools/filesystem.tool';
+import { CalculatorTool } from '../tools/calculator.tool';
+import { JsonPathTool } from '../tools/jsonpath.tool';
+import { createSqlQueryTool, IQueryExecutor } from '../tools/sql-query.tool';
+import {
+  createVectorSearchTool,
+  IVectorSearchProvider,
+  VectorSearchResult,
+} from '../tools/vector-search.tool';
+
+// ─── HttpTool ─────────────────────────────────────────────────────────────────
+
+describe('HttpTool', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  function mockFetch(body: string, status = 200, contentType = 'application/json') {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 200 ? 'OK' : 'Error',
+      headers: { get: () => contentType },
+      text: async () => body,
+    }) as unknown as typeof fetch;
+  }
+
+  it('has correct name and required parameter', () => {
+    expect(HttpTool.definition.name).toBe('http');
+    expect(HttpTool.definition.parameters.required).toContain('url');
+  });
+
+  it('makes a GET request and returns JSON response', async () => {
+    mockFetch(JSON.stringify({ message: 'hello' }));
+    const result = await HttpTool.execute({ url: 'https://api.example.com/test' }, {} as any);
+    expect(result).toContain('"message"');
+    expect(result).toContain('"hello"');
+  });
+
+  it('returns HTTP error status for non-2xx', async () => {
+    mockFetch('Not Found', 404, 'text/plain');
+    const result = await HttpTool.execute({ url: 'https://api.example.com/missing' }, {} as any);
+    expect(result).toMatch(/HTTP 404/);
+  });
+
+  it('throws on invalid URL', async () => {
+    await expect(HttpTool.execute({ url: 'ftp://invalid' }, {} as any)).rejects.toThrow(
+      /invalid URL/,
+    );
+  });
+
+  it('sends POST with body and sets Content-Type', async () => {
+    mockFetch('{"ok":true}');
+    await HttpTool.execute({
+      url: 'https://api.example.com/data',
+      method: 'POST',
+      body: { key: 'value' },
+    }, {} as any);
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    expect(call[1].method).toBe('POST');
+    expect(call[1].headers['Content-Type']).toBe('application/json');
+    expect(call[1].body).toBe('{"key":"value"}');
+  });
+
+  it('times out and throws AbortError-style error', async () => {
+    global.fetch = jest.fn().mockImplementation(() => {
+      return new Promise((_, reject) => {
+        setTimeout(() => {
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        }, 10);
+      });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      HttpTool.execute({ url: 'https://api.example.com/slow', timeout: 1 }, {} as any),
+    ).rejects.toThrow(/timed out/);
+  });
+
+  it('returns plain text for non-JSON responses', async () => {
+    mockFetch('<html>page</html>', 200, 'text/html');
+    const result = await HttpTool.execute({ url: 'https://example.com' }, {} as any);
+    expect(result).toContain('<html>');
+  });
+});
+
+// ─── FilesystemTool ───────────────────────────────────────────────────────────
+
+describe('FilesystemTool', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fox-fs-tool-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes and reads a file', async () => {
+    const filePath = path.join(tmpDir, 'hello.txt');
+    await FilesystemTool.execute({ operation: 'write', path: filePath, content: 'hello world' }, {} as any);
+    const result = await FilesystemTool.execute({ operation: 'read', path: filePath }, {} as any);
+    expect(result).toContain('hello world');
+  });
+
+  it('appends to a file', async () => {
+    const filePath = path.join(tmpDir, 'append.txt');
+    await FilesystemTool.execute({ operation: 'write', path: filePath, content: 'line1\n' }, {} as any);
+    await FilesystemTool.execute({ operation: 'append', path: filePath, content: 'line2\n' }, {} as any);
+    const result = await FilesystemTool.execute({ operation: 'read', path: filePath }, {} as any);
+    expect(result).toContain('line1');
+    expect(result).toContain('line2');
+  });
+
+  it('lists directory contents', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'a.txt'), 'a');
+    fs.writeFileSync(path.join(tmpDir, 'b.txt'), 'b');
+    const result = await FilesystemTool.execute({ operation: 'list', path: tmpDir }, {} as any);
+    expect(result).toContain('a.txt');
+    expect(result).toContain('b.txt');
+  });
+
+  it('checks if file exists', async () => {
+    const filePath = path.join(tmpDir, 'exists.txt');
+    let result = await FilesystemTool.execute({ operation: 'exists', path: filePath }, {} as any);
+    expect(result).toContain('not found');
+    fs.writeFileSync(filePath, 'x');
+    result = await FilesystemTool.execute({ operation: 'exists', path: filePath }, {} as any);
+    expect(result).toContain('file');
+  });
+
+  it('deletes a file', async () => {
+    const filePath = path.join(tmpDir, 'del.txt');
+    fs.writeFileSync(filePath, 'bye');
+    await FilesystemTool.execute({ operation: 'delete', path: filePath }, {} as any);
+    expect(fs.existsSync(filePath)).toBe(false);
+  });
+
+  it('creates a directory', async () => {
+    const dirPath = path.join(tmpDir, 'nested', 'dir');
+    await FilesystemTool.execute({ operation: 'mkdir', path: dirPath }, {} as any);
+    expect(fs.existsSync(dirPath)).toBe(true);
+  });
+
+  it('enforces allowedBase restriction', async () => {
+    const restricted = createFilesystemTool({ allowedBase: tmpDir });
+    await expect(
+      restricted.execute({ operation: 'read', path: '/etc/passwd' }, {} as any),
+    ).rejects.toThrow(/outside allowed base/);
+  });
+
+  it('throws when reading non-existent file', async () => {
+    await expect(
+      FilesystemTool.execute({ operation: 'read', path: path.join(tmpDir, 'nope.txt') }, {} as any),
+    ).rejects.toThrow(/not found/);
+  });
+});
+
+// ─── CalculatorTool ───────────────────────────────────────────────────────────
+
+describe('CalculatorTool', () => {
+  async function calc(expression: string): Promise<string> {
+    return CalculatorTool.execute({ expression }, {} as any) as Promise<string>;
+  }
+
+  it('evaluates basic arithmetic', async () => {
+    expect(await calc('2 + 3')).toBe('2 + 3 = 5');
+    expect(await calc('10 - 4')).toBe('10 - 4 = 6');
+    expect(await calc('3 * 7')).toBe('3 * 7 = 21');
+    expect(await calc('15 / 4')).toBe('15 / 4 = 3.75');
+  });
+
+  it('evaluates exponentiation', async () => {
+    expect(await calc('2 ** 8')).toBe('2 ** 8 = 256');
+    expect(await calc('3 ** 3')).toBe('3 ** 3 = 27');
+  });
+
+  it('evaluates modulo', async () => {
+    expect(await calc('17 % 5')).toBe('17 % 5 = 2');
+  });
+
+  it('handles parentheses and operator precedence', async () => {
+    expect(await calc('(2 + 3) * 4')).toBe('(2 + 3) * 4 = 20');
+    expect(await calc('2 + 3 * 4')).toBe('2 + 3 * 4 = 14');
+  });
+
+  it('handles math functions', async () => {
+    const r = await calc('sqrt(144)');
+    expect(r).toBe('sqrt(144) = 12');
+    const r2 = await calc('abs(-42)');
+    expect(r2).toBe('abs(-42) = 42');
+  });
+
+  it('handles math constants', async () => {
+    const r = await calc('PI');
+    expect(r).toContain('3.14159');
+  });
+
+  it('handles negative numbers', async () => {
+    expect(await calc('-5 + 3')).toBe('-5 + 3 = -2');
+  });
+
+  it('throws on division by zero', async () => {
+    await expect(calc('10 / 0')).rejects.toThrow(/division by zero/);
+  });
+
+  it('throws on unknown identifiers', async () => {
+    await expect(calc('foo + 1')).rejects.toThrow(/unknown identifier/);
+  });
+
+  it('handles chained exponentiation (right-assoc)', async () => {
+    // 2**3**2 = 2**(3**2) = 2**9 = 512
+    const r = await calc('2 ** 3 ** 2');
+    expect(r).toBe('2 ** 3 ** 2 = 512');
+  });
+});
+
+// ─── JsonPathTool ─────────────────────────────────────────────────────────────
+
+describe('JsonPathTool', () => {
+  const sample = JSON.stringify({
+    users: [
+      { name: 'Alice', age: 30, roles: ['admin', 'user'] },
+      { name: 'Bob', age: 25, roles: ['user'] },
+    ],
+    meta: { total: 2, page: 1 },
+  });
+
+  async function query(json: string, path: string, operation?: string): Promise<string> {
+    return JsonPathTool.execute({ json, path, operation }, {} as any) as Promise<string>;
+  }
+
+  it('gets a nested field', async () => {
+    const result = await query(sample, '.meta.total');
+    expect(result).toBe('2');
+  });
+
+  it('gets an array element', async () => {
+    const result = await query(sample, '.users[0].name');
+    expect(result).toBe('"Alice"');
+  });
+
+  it('gets all values with .*', async () => {
+    const result = await query(sample, '.meta.*');
+    expect(result).toContain('2');
+    expect(result).toContain('1');
+  });
+
+  it('counts array elements', async () => {
+    const result = await query(sample, '.users', 'count');
+    expect(result).toBe('2');
+  });
+
+  it('lists keys of an object', async () => {
+    const result = await query(sample, '.meta', 'keys');
+    expect(result).toContain('total');
+    expect(result).toContain('page');
+  });
+
+  it('flattens nested arrays', async () => {
+    const json = JSON.stringify([[1, 2], [3, [4, 5]]]);
+    const result = await query(json, '.', 'flatten');
+    const parsed = JSON.parse(result);
+    expect(parsed).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('returns root with "." path', async () => {
+    const result = await query('{"a":1}', '.');
+    expect(JSON.parse(result)).toEqual({ a: 1 });
+  });
+
+  it('throws on invalid JSON', async () => {
+    await expect(query('not json', '.')).rejects.toThrow(/invalid JSON/);
+  });
+});
+
+// ─── SqlQueryTool ─────────────────────────────────────────────────────────────
+
+describe('SqlQueryTool', () => {
+  function makeExecutor(rows: unknown[], rowCount?: number): IQueryExecutor {
+    return {
+      query: jest.fn().mockResolvedValue({ rows, rowCount: rowCount ?? rows.length }),
+    };
+  }
+
+  it('returns a markdown table for SELECT results', async () => {
+    const executor = makeExecutor([
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+    ]);
+    const tool = createSqlQueryTool(executor);
+    const result = await tool.execute({ sql: 'SELECT * FROM users' }, {} as any);
+    expect(result).toContain('| id | name |');
+    expect(result).toContain('| 1 | Alice |');
+    expect(result).toContain('| 2 | Bob |');
+  });
+
+  it('returns "0 rows" message for empty results', async () => {
+    const executor = makeExecutor([]);
+    const tool = createSqlQueryTool(executor);
+    const result = await tool.execute({ sql: 'SELECT * FROM empty' }, {} as any);
+    expect(result).toContain('0 rows');
+  });
+
+  it('blocks mutation statements by default', async () => {
+    const executor = makeExecutor([]);
+    const tool = createSqlQueryTool(executor);
+    await expect(
+      tool.execute({ sql: 'DELETE FROM users WHERE id = 1' }, {} as any),
+    ).rejects.toThrow(/mutation statements are not allowed/);
+  });
+
+  it('allows mutations when configured', async () => {
+    const executor = makeExecutor([], 1);
+    const tool = createSqlQueryTool(executor, { allowMutations: true });
+    const result = await tool.execute({ sql: 'DELETE FROM users WHERE id = 1' }, {} as any);
+    expect(result).toContain('0 rows');
+  });
+
+  it('truncates results at maxRows', async () => {
+    const rows = Array.from({ length: 150 }, (_, i) => ({ id: i }));
+    const executor = makeExecutor(rows);
+    const tool = createSqlQueryTool(executor, { maxRows: 10 });
+    const result = await tool.execute({ sql: 'SELECT * FROM big' }, {} as any);
+    expect(result).toContain('truncated to 10 rows');
+  });
+
+  it('passes params to executor', async () => {
+    const executor = makeExecutor([{ id: 5 }]);
+    const tool = createSqlQueryTool(executor);
+    await tool.execute({ sql: 'SELECT * FROM users WHERE id = $1', params: [5] }, {} as any);
+    expect((executor.query as jest.Mock).mock.calls[0][1]).toEqual([5]);
+  });
+});
+
+// ─── VectorSearchTool ─────────────────────────────────────────────────────────
+
+describe('VectorSearchTool', () => {
+  function makeProvider(results: VectorSearchResult[]): IVectorSearchProvider {
+    return {
+      search: jest.fn().mockResolvedValue(results),
+    };
+  }
+
+  it('returns formatted results', async () => {
+    const provider = makeProvider([
+      { id: '1', score: 0.95, text: 'Fox Framework is a TypeScript web framework.' },
+      { id: '2', score: 0.88, text: 'It supports agents and LLMs natively.' },
+    ]);
+    const tool = createVectorSearchTool(provider);
+    const result = await tool.execute({ query: 'what is fox framework' }, {} as any);
+    expect(result).toContain('0.9500');
+    expect(result).toContain('Fox Framework');
+    expect(result).toContain('0.8800');
+  });
+
+  it('returns "no results" message when empty', async () => {
+    const provider = makeProvider([]);
+    const tool = createVectorSearchTool(provider);
+    const result = await tool.execute({ query: 'nothing' }, {} as any);
+    expect(result).toContain('No results found');
+  });
+
+  it('passes topK and minScore to provider', async () => {
+    const provider = makeProvider([]);
+    const tool = createVectorSearchTool(provider);
+    await tool.execute({ query: 'test', top_k: 3, min_score: 0.7 }, {} as any);
+    expect((provider.search as jest.Mock).mock.calls[0][1]).toMatchObject({
+      topK: 3,
+      minScore: 0.7,
+    });
+  });
+
+  it('includes metadata in output', async () => {
+    const provider = makeProvider([
+      { id: '1', score: 0.9, text: 'result', metadata: { source: 'wiki', year: 2024 } },
+    ]);
+    const tool = createVectorSearchTool(provider);
+    const result = await tool.execute({ query: 'test' }, {} as any);
+    expect(result).toContain('source=wiki');
+    expect(result).toContain('year=2024');
+  });
+
+  it('uses custom label and description', async () => {
+    const provider = makeProvider([]);
+    const tool = createVectorSearchTool(provider, {
+      label: 'knowledge_base',
+      description: 'Search the KB',
+    });
+    expect(tool.definition.name).toBe('knowledge_base');
+    expect(tool.definition.description).toBe('Search the KB');
+  });
+});

--- a/tsfox/core/agents/index.ts
+++ b/tsfox/core/agents/index.ts
@@ -69,3 +69,20 @@ export type {
   CachedAgentOptions,
   AgentMetricSnapshot,
 } from './integrations';
+
+// Tools
+export {
+  HttpTool,
+  FilesystemTool,
+  createFilesystemTool,
+  CalculatorTool,
+  JsonPathTool,
+  createSqlQueryTool,
+  createVectorSearchTool,
+} from './tools';
+export type {
+  IQueryExecutor,
+  IVectorSearchProvider,
+  VectorSearchOptions,
+  VectorSearchResult,
+} from './tools';

--- a/tsfox/core/agents/tools/calculator.tool.ts
+++ b/tsfox/core/agents/tools/calculator.tool.ts
@@ -1,0 +1,158 @@
+import { ITool, AgentContext } from '../interfaces/agent.interface';
+
+export const CalculatorTool: ITool = {
+  definition: {
+    name: 'calculator',
+    description:
+      'Evaluate mathematical expressions. Supports arithmetic (+, -, *, /, **, %), ' +
+      'parentheses, and math functions: sqrt, abs, ceil, floor, round, log, sin, cos, tan. ' +
+      'Constants: PI, E. Example: "sqrt(144) + 2 ** 8"',
+    parameters: {
+      type: 'object',
+      properties: {
+        expression: {
+          type: 'string',
+          description: 'Mathematical expression to evaluate',
+        },
+      },
+      required: ['expression'],
+    },
+  },
+
+  async execute(params: Record<string, unknown>, _ctx: AgentContext): Promise<string> {
+    const expression = (params.expression as string).trim();
+    try {
+      const result = evaluate(expression);
+      return `${expression} = ${result}`;
+    } catch (err: unknown) {
+      throw new Error(`CalculatorTool: ${(err as Error).message}`);
+    }
+  },
+};
+
+// ─── Safe expression parser ──────────────────────────────────────────────────
+
+const MATH_FUNS: Record<string, (x: number) => number> = {
+  sqrt: Math.sqrt, abs: Math.abs, ceil: Math.ceil, floor: Math.floor,
+  round: Math.round, log: Math.log, log2: Math.log2, log10: Math.log10,
+  sin: Math.sin, cos: Math.cos, tan: Math.tan,
+  asin: Math.asin, acos: Math.acos, atan: Math.atan,
+  exp: Math.exp, sign: Math.sign, trunc: Math.trunc,
+};
+
+const MATH_CONSTS: Record<string, number> = {
+  PI: Math.PI, E: Math.E, LN2: Math.LN2, LN10: Math.LN10, SQRT2: Math.SQRT2,
+};
+
+function evaluate(expr: string): number {
+  const tokens = tokenise(expr);
+  const ctx = { tokens, pos: 0 };
+  const result = parseExpr(ctx);
+  if (ctx.pos < ctx.tokens.length) {
+    throw new Error(`unexpected token "${ctx.tokens[ctx.pos].value}" at position ${ctx.pos}`);
+  }
+  return result;
+}
+
+type Token = { type: 'num' | 'op' | 'lparen' | 'rparen' | 'ident'; value: string };
+type Ctx = { tokens: Token[]; pos: number };
+
+function tokenise(expr: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  while (i < expr.length) {
+    const ch = expr[i];
+    if (/\s/.test(ch)) { i++; continue; }
+    if (/\d/.test(ch) || (ch === '.' && /\d/.test(expr[i + 1] ?? ''))) {
+      let num = '';
+      while (i < expr.length && /[\d.]/.test(expr[i])) num += expr[i++];
+      tokens.push({ type: 'num', value: num });
+    } else if (/[a-zA-Z_]/.test(ch)) {
+      let ident = '';
+      while (i < expr.length && /[a-zA-Z0-9_]/.test(expr[i])) ident += expr[i++];
+      tokens.push({ type: 'ident', value: ident });
+    } else if (ch === '(') {
+      tokens.push({ type: 'lparen', value: ch }); i++;
+    } else if (ch === ')') {
+      tokens.push({ type: 'rparen', value: ch }); i++;
+    } else if ('+-*/%^'.includes(ch)) {
+      if (ch === '*' && expr[i + 1] === '*') {
+        tokens.push({ type: 'op', value: '**' }); i += 2;
+      } else {
+        tokens.push({ type: 'op', value: ch }); i++;
+      }
+    } else {
+      throw new Error(`unexpected character "${ch}"`);
+    }
+  }
+  return tokens;
+}
+
+function peek(ctx: Ctx): Token | undefined { return ctx.tokens[ctx.pos]; }
+function consume(ctx: Ctx): Token { return ctx.tokens[ctx.pos++]; }
+
+function parseExpr(ctx: Ctx): number { return parseAddSub(ctx); }
+
+function parseAddSub(ctx: Ctx): number {
+  let left = parseMulDiv(ctx);
+  while (peek(ctx)?.type === 'op' && (peek(ctx)!.value === '+' || peek(ctx)!.value === '-')) {
+    const op = consume(ctx).value;
+    const right = parseMulDiv(ctx);
+    left = op === '+' ? left + right : left - right;
+  }
+  return left;
+}
+
+function parseMulDiv(ctx: Ctx): number {
+  let left = parsePow(ctx);
+  while (peek(ctx)?.type === 'op' && ['*', '/', '%'].includes(peek(ctx)!.value)) {
+    const op = consume(ctx).value;
+    const right = parsePow(ctx);
+    if (op === '*') left *= right;
+    else if (op === '/') { if (right === 0) throw new Error('division by zero'); left /= right; }
+    else left %= right;
+  }
+  return left;
+}
+
+function parsePow(ctx: Ctx): number {
+  const base = parseUnary(ctx);
+  if (peek(ctx)?.type === 'op' && peek(ctx)!.value === '**') {
+    consume(ctx);
+    return Math.pow(base, parsePow(ctx));
+  }
+  return base;
+}
+
+function parseUnary(ctx: Ctx): number {
+  if (peek(ctx)?.type === 'op' && peek(ctx)!.value === '-') { consume(ctx); return -parsePrimary(ctx); }
+  if (peek(ctx)?.type === 'op' && peek(ctx)!.value === '+') { consume(ctx); }
+  return parsePrimary(ctx);
+}
+
+function parsePrimary(ctx: Ctx): number {
+  const tok = peek(ctx);
+  if (!tok) throw new Error('unexpected end of expression');
+  if (tok.type === 'num') { consume(ctx); return parseFloat(tok.value); }
+  if (tok.type === 'lparen') {
+    consume(ctx);
+    const val = parseExpr(ctx);
+    if (peek(ctx)?.type !== 'rparen') throw new Error('missing closing parenthesis');
+    consume(ctx);
+    return val;
+  }
+  if (tok.type === 'ident') {
+    consume(ctx);
+    if (tok.value in MATH_CONSTS) return MATH_CONSTS[tok.value];
+    if (tok.value in MATH_FUNS) {
+      if (peek(ctx)?.type !== 'lparen') throw new Error(`expected "(" after "${tok.value}"`);
+      consume(ctx);
+      const arg = parseExpr(ctx);
+      if (peek(ctx)?.type !== 'rparen') throw new Error(`missing ")" after "${tok.value}(...)"`);
+      consume(ctx);
+      return MATH_FUNS[tok.value](arg);
+    }
+    throw new Error(`unknown identifier "${tok.value}"`);
+  }
+  throw new Error(`unexpected token "${tok.value}"`);
+}

--- a/tsfox/core/agents/tools/filesystem.tool.ts
+++ b/tsfox/core/agents/tools/filesystem.tool.ts
@@ -1,0 +1,105 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { ITool, AgentContext } from '../interfaces/agent.interface';
+
+export function createFilesystemTool(options: { allowedBase?: string } = {}): ITool {
+  const allowedBase = options.allowedBase ? path.resolve(options.allowedBase) : null;
+
+  function safeResolve(filePath: string): string {
+    const resolved = path.resolve(filePath);
+    if (allowedBase && !resolved.startsWith(allowedBase + path.sep) && resolved !== allowedBase) {
+      throw new Error(
+        `FilesystemTool: path "${filePath}" is outside allowed base "${allowedBase}"`,
+      );
+    }
+    return resolved;
+  }
+
+  return {
+    definition: {
+      name: 'filesystem',
+      description:
+        'Read, write, append, list, delete files and directories on the local filesystem.',
+      parameters: {
+        type: 'object',
+        properties: {
+          operation: {
+            type: 'string',
+            enum: ['read', 'write', 'append', 'list', 'exists', 'delete', 'mkdir'],
+            description: 'Filesystem operation to perform',
+          },
+          path: {
+            type: 'string',
+            description: 'File or directory path',
+          },
+          content: {
+            type: 'string',
+            description: 'Content to write or append',
+          },
+          encoding: {
+            type: 'string',
+            enum: ['utf8', 'base64', 'hex'],
+            description: 'File encoding (default: utf8)',
+          },
+        },
+        required: ['operation', 'path'],
+      },
+    },
+
+    async execute(params: Record<string, unknown>, _ctx: AgentContext): Promise<string> {
+      const operation = params.operation as string;
+      const filePath = safeResolve(params.path as string);
+      const encoding = (params.encoding as BufferEncoding) ?? 'utf8';
+
+      switch (operation) {
+        case 'read': {
+          if (!fs.existsSync(filePath)) throw new Error(`FilesystemTool: file not found: "${filePath}"`);
+          const content = fs.readFileSync(filePath, encoding);
+          const stats = fs.statSync(filePath);
+          return `File: ${filePath} (${stats.size} bytes)\n\n${content}`;
+        }
+        case 'write': {
+          const content = (params.content as string) ?? '';
+          const dir = path.dirname(filePath);
+          if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+          fs.writeFileSync(filePath, content, encoding);
+          return `Written ${content.length} characters to "${filePath}"`;
+        }
+        case 'append': {
+          const content = (params.content as string) ?? '';
+          fs.appendFileSync(filePath, content, encoding);
+          const stats = fs.statSync(filePath);
+          return `Appended ${content.length} characters to "${filePath}" (total: ${stats.size} bytes)`;
+        }
+        case 'list': {
+          if (!fs.existsSync(filePath)) throw new Error(`FilesystemTool: directory not found: "${filePath}"`);
+          const entries = fs.readdirSync(filePath, { withFileTypes: true });
+          const lines = entries.map((e) => {
+            const type = e.isDirectory() ? 'd' : 'f';
+            const size = type === 'f' ? fs.statSync(path.join(filePath, e.name)).size : '-';
+            return `[${type}] ${e.name}${type === 'f' ? ` (${size} bytes)` : '/'}`;
+          });
+          return `Contents of "${filePath}" (${lines.length} entries):\n${lines.join('\n')}`;
+        }
+        case 'exists': {
+          const exists = fs.existsSync(filePath);
+          const type = exists ? (fs.statSync(filePath).isDirectory() ? 'directory' : 'file') : 'not found';
+          return `"${filePath}": ${type}`;
+        }
+        case 'delete': {
+          if (!fs.existsSync(filePath)) return `"${filePath}" does not exist (nothing to delete)`;
+          fs.unlinkSync(filePath);
+          return `Deleted "${filePath}"`;
+        }
+        case 'mkdir': {
+          fs.mkdirSync(filePath, { recursive: true });
+          return `Directory created: "${filePath}"`;
+        }
+        default:
+          throw new Error(`FilesystemTool: unknown operation "${operation}"`);
+      }
+    },
+  };
+}
+
+export const FilesystemTool: ITool = createFilesystemTool();

--- a/tsfox/core/agents/tools/http.tool.ts
+++ b/tsfox/core/agents/tools/http.tool.ts
@@ -1,0 +1,100 @@
+import { ITool, AgentContext } from '../interfaces/agent.interface';
+
+/**
+ * HttpTool — makes HTTP requests (GET, POST, PUT, PATCH, DELETE)
+ */
+export const HttpTool: ITool = {
+  definition: {
+    name: 'http',
+    description:
+      'Make HTTP requests to external URLs. Supports GET, POST, PUT, PATCH, DELETE. ' +
+      'Returns the response body as text or JSON.',
+    parameters: {
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          description: 'The full URL to request (must start with http:// or https://)',
+        },
+        method: {
+          type: 'string',
+          enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
+          description: 'HTTP method (default: GET)',
+        },
+        headers: {
+          type: 'object',
+          description: 'Optional HTTP headers as key-value pairs',
+        },
+        body: {
+          type: 'string',
+          description: 'Optional request body. Objects are serialised to JSON automatically.',
+        },
+        timeout: {
+          type: 'number',
+          description: 'Request timeout in milliseconds (default: 10000)',
+        },
+      },
+      required: ['url'],
+    },
+  },
+
+  async execute(params: Record<string, unknown>, _context: AgentContext): Promise<string> {
+    const url = params.url as string;
+    const method = ((params.method as string) ?? 'GET').toUpperCase();
+    const headers = (params.headers as Record<string, string>) ?? {};
+    const timeoutMs = (params.timeout as number) ?? 10_000;
+
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      throw new Error(`HttpTool: invalid URL "${url}" — must start with http:// or https://`);
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    let bodyStr: string | undefined;
+    if (params.body !== undefined) {
+      if (typeof params.body === 'string') {
+        bodyStr = params.body;
+      } else {
+        bodyStr = JSON.stringify(params.body);
+        if (!headers['Content-Type'] && !headers['content-type']) {
+          headers['Content-Type'] = 'application/json';
+        }
+      }
+    }
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers,
+        body: bodyStr,
+        signal: controller.signal,
+      });
+
+      clearTimeout(timer);
+
+      const contentType = response.headers.get('content-type') ?? '';
+      const text = await response.text();
+
+      if (!response.ok) {
+        return `HTTP ${response.status} ${response.statusText}\n${text}`;
+      }
+
+      if (contentType.includes('application/json') || contentType.includes('text/json')) {
+        try {
+          return JSON.stringify(JSON.parse(text), null, 2);
+        } catch {
+          return text;
+        }
+      }
+
+      return text;
+    } catch (err: unknown) {
+      clearTimeout(timer);
+      if ((err as Error).name === 'AbortError') {
+        throw new Error(`HttpTool: request to "${url}" timed out after ${timeoutMs}ms`);
+      }
+      throw err;
+    }
+  },
+};

--- a/tsfox/core/agents/tools/index.ts
+++ b/tsfox/core/agents/tools/index.ts
@@ -1,0 +1,13 @@
+export { HttpTool } from './http.tool';
+export { FilesystemTool, createFilesystemTool } from './filesystem.tool';
+export { CalculatorTool } from './calculator.tool';
+export { JsonPathTool } from './jsonpath.tool';
+export { createSqlQueryTool } from './sql-query.tool';
+export { createVectorSearchTool } from './vector-search.tool';
+
+export type { IQueryExecutor } from './sql-query.tool';
+export type {
+  IVectorSearchProvider,
+  VectorSearchOptions,
+  VectorSearchResult,
+} from './vector-search.tool';

--- a/tsfox/core/agents/tools/jsonpath.tool.ts
+++ b/tsfox/core/agents/tools/jsonpath.tool.ts
@@ -1,0 +1,112 @@
+import { ITool, AgentContext } from '../interfaces/agent.interface';
+
+export const JsonPathTool: ITool = {
+  definition: {
+    name: 'jsonpath',
+    description:
+      'Extract and query data from JSON. Navigate objects and arrays using dot/bracket paths. ' +
+      'Operations: get, keys, count, flatten, pretty. ' +
+      'Example: path=".users[0].name", operation="get"',
+    parameters: {
+      type: 'object',
+      properties: {
+        json: {
+          type: 'string',
+          description: 'JSON string to query',
+        },
+        path: {
+          type: 'string',
+          description: 'Path expression: "." for root, ".field", "[0]", ".*", "[*]"',
+        },
+        operation: {
+          type: 'string',
+          enum: ['get', 'keys', 'count', 'flatten', 'pretty'],
+          description: 'Operation to perform (default: get)',
+        },
+      },
+      required: ['json', 'path'],
+    },
+  },
+
+  async execute(params: Record<string, unknown>, _ctx: AgentContext): Promise<string> {
+    const operation = (params.operation as string) ?? 'get';
+    let data: unknown;
+
+    if (typeof params.json === 'string') {
+      try { data = JSON.parse(params.json as string); }
+      catch { throw new Error('JsonPathTool: invalid JSON input'); }
+    } else {
+      data = params.json;
+    }
+
+    const pathStr = (params.path as string).trim();
+    const value = resolvePath(data, pathStr);
+
+    switch (operation) {
+      case 'get': return JSON.stringify(value, null, 2);
+      case 'keys': {
+        if (typeof value !== 'object' || value === null)
+          throw new Error(`JsonPathTool: cannot get keys of non-object at "${pathStr}"`);
+        const keys = Array.isArray(value)
+          ? value.map((_, i) => String(i))
+          : Object.keys(value as object);
+        return keys.join(', ');
+      }
+      case 'count': {
+        if (Array.isArray(value)) return String(value.length);
+        if (typeof value === 'object' && value !== null) return String(Object.keys(value as object).length);
+        if (typeof value === 'string') return String(value.length);
+        throw new Error(`JsonPathTool: cannot count "${typeof value}"`);
+      }
+      case 'flatten': {
+        if (!Array.isArray(value)) throw new Error('JsonPathTool: flatten requires an array');
+        return JSON.stringify(flatDeep(value), null, 2);
+      }
+      case 'pretty': return JSON.stringify(value, null, 2);
+      default: throw new Error(`JsonPathTool: unknown operation "${operation}"`);
+    }
+  },
+};
+
+function resolvePath(data: unknown, pathStr: string): unknown {
+  if (pathStr === '.' || pathStr === '') return data;
+  const tokens: Array<{ type: 'key' | 'index' | 'wildcard_obj' | 'wildcard_arr'; value: string }> = [];
+  const re = /\.(\*)|\.([a-zA-Z_$][a-zA-Z0-9_$]*|\d+)|\[(\*|\d+)\]/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(pathStr)) !== null) {
+    if (match[1] !== undefined) tokens.push({ type: 'wildcard_obj', value: '*' });
+    else if (match[2] !== undefined) tokens.push({ type: 'key', value: match[2] });
+    else if (match[3] === '*') tokens.push({ type: 'wildcard_arr', value: '*' });
+    else tokens.push({ type: 'index', value: match[3] });
+  }
+  if (tokens.length === 0) throw new Error(`JsonPathTool: invalid path "${pathStr}"`);
+
+  let current: unknown = data;
+  for (const token of tokens) {
+    if (current === null || current === undefined)
+      throw new Error(`JsonPathTool: null/undefined at path "${pathStr}"`);
+    if (token.type === 'key') {
+      if (typeof current !== 'object' || Array.isArray(current))
+        throw new Error(`JsonPathTool: expected object for ".${token.value}"`);
+      current = (current as Record<string, unknown>)[token.value];
+    } else if (token.type === 'index') {
+      if (!Array.isArray(current)) throw new Error(`JsonPathTool: expected array for "[${token.value}]"`);
+      const idx = parseInt(token.value, 10);
+      current = (current as unknown[])[idx < 0 ? current.length + idx : idx];
+    } else if (token.type === 'wildcard_obj') {
+      if (typeof current !== 'object' || Array.isArray(current))
+        throw new Error('JsonPathTool: ".*" requires an object');
+      current = Object.values(current as object);
+    }
+    // wildcard_arr: return as-is
+  }
+  return current;
+}
+
+function flatDeep(arr: unknown[]): unknown[] {
+  return arr.reduce<unknown[]>((acc, val) => {
+    if (Array.isArray(val)) acc.push(...flatDeep(val));
+    else acc.push(val);
+    return acc;
+  }, []);
+}

--- a/tsfox/core/agents/tools/sql-query.tool.ts
+++ b/tsfox/core/agents/tools/sql-query.tool.ts
@@ -1,0 +1,71 @@
+import { ITool, AgentContext } from '../interfaces/agent.interface';
+
+export interface IQueryExecutor {
+  query(sql: string, params?: unknown[]): Promise<{ rows: unknown[]; rowCount: number }>;
+}
+
+export function createSqlQueryTool(
+  executor: IQueryExecutor,
+  options: { allowMutations?: boolean; maxRows?: number; label?: string } = {},
+): ITool {
+  const allowMutations = options.allowMutations ?? false;
+  const maxRows = options.maxRows ?? 100;
+  const toolName = options.label ?? 'sql_query';
+
+  return {
+    definition: {
+      name: toolName,
+      description:
+        'Execute SQL queries against the connected database. ' +
+        (allowMutations
+          ? 'Supports SELECT, INSERT, UPDATE, DELETE.'
+          : 'Read-only: only SELECT statements are permitted.') +
+        ` Results are capped at ${maxRows} rows.`,
+      parameters: {
+        type: 'object',
+        properties: {
+          sql: { type: 'string', description: 'SQL statement to execute' },
+          params: {
+            type: 'array',
+            description: 'Optional parameterised values',
+            items: { type: 'string' },
+          },
+        },
+        required: ['sql'],
+      },
+    },
+
+    async execute(p: Record<string, unknown>, _ctx: AgentContext): Promise<string> {
+      const sql = (p.sql as string).trim();
+      const params = (p.params as unknown[]) ?? [];
+
+      if (!allowMutations) {
+        const upper = sql.toUpperCase().replace(/\s+/g, ' ');
+        if (/^(INSERT|UPDATE|DELETE|DROP|TRUNCATE|ALTER|CREATE|REPLACE)/.test(upper)) {
+          throw new Error(`SqlQueryTool: mutation statements are not allowed.`);
+        }
+      }
+
+      const result = await executor.query(sql, params);
+      const rows = result.rows.slice(0, maxRows);
+
+      if (rows.length === 0) return `Query executed. 0 rows returned. (rowCount: ${result.rowCount})`;
+
+      const headers = Object.keys(rows[0] as object);
+      const sep = headers.map(() => '---');
+      const body = rows.map((row) => {
+        const vals = headers.map((h) => {
+          const v = (row as Record<string, unknown>)[h];
+          return v === null || v === undefined ? 'NULL' : String(v);
+        });
+        return `| ${vals.join(' | ')} |`;
+      }).join('\n');
+
+      const truncNote = result.rows.length > maxRows
+        ? `\n\n*Results truncated to ${maxRows} rows (total: ${result.rows.length})*`
+        : '';
+
+      return `| ${headers.join(' | ')} |\n| ${sep.join(' | ')} |\n${body}${truncNote}`;
+    },
+  };
+}

--- a/tsfox/core/agents/tools/vector-search.tool.ts
+++ b/tsfox/core/agents/tools/vector-search.tool.ts
@@ -1,0 +1,72 @@
+import { ITool, AgentContext } from '../interfaces/agent.interface';
+
+export interface IVectorSearchProvider {
+  search(query: string, options?: VectorSearchOptions): Promise<VectorSearchResult[]>;
+  upsert?(id: string, text: string, metadata?: Record<string, unknown>): Promise<void>;
+  delete?(id: string): Promise<void>;
+}
+
+export interface VectorSearchOptions {
+  topK?: number;
+  minScore?: number;
+  filter?: Record<string, unknown>;
+  namespace?: string;
+}
+
+export interface VectorSearchResult {
+  id: string;
+  score: number;
+  text: string;
+  metadata?: Record<string, unknown>;
+}
+
+export function createVectorSearchTool(
+  provider: IVectorSearchProvider,
+  options: { label?: string; description?: string; defaultTopK?: number; defaultMinScore?: number } = {},
+): ITool {
+  const toolName = options.label ?? 'vector_search';
+  const defaultTopK = options.defaultTopK ?? 5;
+  const defaultMinScore = options.defaultMinScore ?? 0.0;
+
+  return {
+    definition: {
+      name: toolName,
+      description:
+        options.description ??
+        'Perform semantic similarity search over a vector store. ' +
+          'Returns the most relevant documents based on meaning, not just keywords.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Natural language query for semantic search' },
+          top_k: { type: 'number', description: `Number of results to return (default: ${defaultTopK})` },
+          min_score: { type: 'number', description: `Minimum similarity score 0.0–1.0 (default: ${defaultMinScore})` },
+          filter: { type: 'object', description: 'Optional metadata filter' },
+          namespace: { type: 'string', description: 'Optional namespace/collection to search in' },
+        },
+        required: ['query'],
+      },
+    },
+
+    async execute(params: Record<string, unknown>, _ctx: AgentContext): Promise<string> {
+      const query = params.query as string;
+      const topK = (params.top_k as number) ?? defaultTopK;
+      const minScore = (params.min_score as number) ?? defaultMinScore;
+      const filter = params.filter as Record<string, unknown> | undefined;
+      const namespace = params.namespace as string | undefined;
+
+      const results = await provider.search(query, { topK, minScore, filter, namespace });
+
+      if (results.length === 0) return `No results found for query: "${query}"`;
+
+      const lines = results.map((r, i) => {
+        const meta = r.metadata && Object.keys(r.metadata).length > 0
+          ? ` [${Object.entries(r.metadata).map(([k, v]) => `${k}=${v}`).join(', ')}]`
+          : '';
+        return `${i + 1}. (score: ${r.score.toFixed(4)})${meta}\n   ${r.text}`;
+      });
+
+      return `Vector search results for "${query}" (${results.length} found):\n\n${lines.join('\n\n')}`;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add six production-ready `ITool` implementations to `tsfox/core/agents/tools/`
- All tools conform to the canonical `ITool` interface: `{ definition: ToolDefinition; execute(args, context): Promise<unknown> }`
- 44 tests passing, zero regressions

## Tools Added

| Tool | Factory | Description |
|------|---------|-------------|
| `HttpTool` | singleton | fetch-based HTTP client — GET/POST/PUT/PATCH/DELETE, timeout, binary support |
| `FilesystemTool` / `createFilesystemTool` | both | read/write/append/list/delete/mkdir, optional `allowedBase` sandbox |
| `CalculatorTool` | singleton | safe recursive-descent expression parser (no `eval`), math functions + constants |
| `JsonPathTool` | singleton | JSON query engine — get/keys/count/flatten/pretty, dot+bracket path notation |
| `createSqlQueryTool` | factory | `IQueryExecutor` adapter, read-only by default, markdown-table output, row cap |
| `createVectorSearchTool` | factory | `IVectorSearchProvider` adapter, topK/minScore/filter/namespace params |

## Files Changed

- `tsfox/core/agents/tools/http.tool.ts` *(new)*
- `tsfox/core/agents/tools/filesystem.tool.ts` *(new)*
- `tsfox/core/agents/tools/calculator.tool.ts` *(new)*
- `tsfox/core/agents/tools/jsonpath.tool.ts` *(new)*
- `tsfox/core/agents/tools/sql-query.tool.ts` *(new)*
- `tsfox/core/agents/tools/vector-search.tool.ts` *(new)*
- `tsfox/core/agents/tools/index.ts` *(new — barrel exports)*
- `tsfox/core/agents/index.ts` *(updated — re-exports tools)*
- `tsfox/core/agents/__tests__/epic-d1.test.ts` *(new — 44 tests)*

## Test Results

```
Test Suites: 1 passed
Tests:       44 passed
```