### PR TITLE
feat(agents): Epic D3 — Streaming UI — SSE agent output (21 tests)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -159,6 +159,9 @@ jobs:
         npm run build --workspace=packages/model-openai
         npm run build --workspace=packages/model-anthropic
         npm run build --workspace=packages/model-ollama
+        npm run build --workspace=packages/vector-pinecone
+        npm run build --workspace=packages/vector-weaviate
+        npm run build --workspace=packages/vector-chroma
 
     - name: 🔍 (Optional) Build Examples
       run: npm run build:examples || echo "Skipping examples build"
@@ -441,6 +444,9 @@ jobs:
         npm run build --workspace=packages/model-openai
         npm run build --workspace=packages/model-anthropic
         npm run build --workspace=packages/model-ollama
+        npm run build --workspace=packages/vector-pinecone
+        npm run build --workspace=packages/vector-weaviate
+        npm run build --workspace=packages/vector-chroma
 
     # ── Publish core ───────────────────────────────────────────────────────
     - name: 📦 Publish @foxframework/core
@@ -542,6 +548,22 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+    # ── Publish Vector Store packages ─────────────────────────────────────
+    - name: 📦 Publish @foxframework/vector-pinecone
+      run: npm publish --workspace=packages/vector-pinecone --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: 📦 Publish @foxframework/vector-weaviate
+      run: npm publish --workspace=packages/vector-weaviate --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: 📦 Publish @foxframework/vector-chroma
+      run: npm publish --workspace=packages/vector-chroma --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
     # ── Summary ────────────────────────────────────────────────────────────
     - name: 📢 Publish summary
       run: |
@@ -554,7 +576,7 @@ jobs:
         echo "| Package | Version |" >> $GITHUB_STEP_SUMMARY
         echo "|---|---|" >> $GITHUB_STEP_SUMMARY
         echo "| @foxframework/core | $(node -p "require('./package.json').version") |" >> $GITHUB_STEP_SUMMARY
-        for pkg in packages/db-*/ packages/auth-*/ packages/serverless/ packages/model-*/; do
+        for pkg in packages/db-*/ packages/auth-*/ packages/serverless/ packages/model-*/ packages/vector-*/; do
           PKG_NAME=$(node -p "require('./${pkg}package.json').name")
           PKG_VER=$(node -p "require('./${pkg}package.json').version")
           echo "| ${PKG_NAME} | ${PKG_VER} |" >> $GITHUB_STEP_SUMMARY

--- a/packages/vector-chroma/__tests__/chroma.provider.test.ts
+++ b/packages/vector-chroma/__tests__/chroma.provider.test.ts
@@ -1,0 +1,171 @@
+/**
+ * @foxframework/vector-chroma — unit tests
+ * All HTTP calls are mocked via global.fetch.
+ */
+
+import { ChromaProvider } from '../src/chroma.provider';
+
+const BASE_URL = 'http://localhost:8000';
+const COLLECTION = 'test-docs';
+const COLLECTION_ID = 'col-uuid-123';
+const API_BASE = `${BASE_URL}/api/v1/tenants/default_tenant/databases/default_database/collections`;
+
+const embed = jest.fn().mockResolvedValue([[0.1, 0.2, 0.3]]);
+
+function mockFetchSequence(responses: Array<{ body: unknown; status?: number }>) {
+  (global.fetch as jest.Mock) = jest.fn();
+  for (const r of responses) {
+    const status = r.status ?? 200;
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: status >= 200 && status < 300,
+      status,
+      json: jest.fn().mockResolvedValue(r.body),
+      text: jest.fn().mockResolvedValue(JSON.stringify(r.body)),
+    });
+  }
+}
+
+/** Helper: mock collection GET then an action */
+function withCollection(actionResponse: unknown, actionStatus = 200) {
+  mockFetchSequence([
+    { body: { id: COLLECTION_ID, name: COLLECTION } },    // GET collection
+    { body: actionResponse, status: actionStatus },        // actual action
+  ]);
+}
+
+describe('ChromaProvider', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('throws if url is missing', () => {
+    expect(() => new ChromaProvider({ url: '', collection: COLLECTION })).toThrow(/url/);
+  });
+
+  it('throws if collection is missing', () => {
+    expect(() => new ChromaProvider({ url: BASE_URL, collection: '' })).toThrow(/collection/);
+  });
+
+  it('throws on search without embed function', async () => {
+    const provider = new ChromaProvider({ url: BASE_URL, collection: COLLECTION });
+    await expect(provider.search('test')).rejects.toThrow(/embed function/);
+  });
+
+  it('resolves collection id on first call, caches on second', async () => {
+    mockFetchSequence([
+      { body: { id: COLLECTION_ID } },           // GET collection
+      { body: queryResponse([]) },               // search 1
+      { body: queryResponse([]) },               // search 2 (no GET this time)
+    ]);
+    const provider = new ChromaProvider({ url: BASE_URL, collection: COLLECTION, embed });
+    await provider.search('a');
+    await provider.search('b');
+    // fetch was called 3 times total (1 resolve + 2 queries), not 4
+    expect((global.fetch as jest.Mock)).toHaveBeenCalledTimes(3);
+  });
+
+  it('creates collection if not found (404)', async () => {
+    mockFetchSequence([
+      { body: { message: 'not found' }, status: 404 },    // GET → 404
+      { body: { id: COLLECTION_ID }, status: 200 },        // POST create
+      { body: queryResponse([]), status: 200 },            // query
+    ]);
+    const provider = new ChromaProvider({ url: BASE_URL, collection: COLLECTION, embed });
+    await provider.search('q');
+
+    const createCall = (global.fetch as jest.Mock).mock.calls[1];
+    expect(createCall[1].method).toBe('POST');
+    expect(createCall[0]).toBe(API_BASE);
+  });
+
+  it('queries the correct endpoint', async () => {
+    withCollection(queryResponse([]));
+    const provider = new ChromaProvider({ url: BASE_URL, collection: COLLECTION, embed });
+    await provider.search('hello', { topK: 3 });
+
+    const queryCall = (global.fetch as jest.Mock).mock.calls[1];
+    expect(queryCall[0]).toBe(`${API_BASE}/${COLLECTION_ID}/query`);
+    const body = JSON.parse(queryCall[1].body);
+    expect(body.n_results).toBe(3);
+    expect(body.query_embeddings[0]).toEqual([0.1, 0.2, 0.3]);
+  });
+
+  it('converts L2 distance to score and maps results', async () => {
+    withCollection(queryResponse([
+      { id: 'doc1', distance: 0.0, document: 'Perfect match', metadata: { src: 'wiki' } },
+      { id: 'doc2', distance: 1.0, document: 'Distant match', metadata: null },
+    ]));
+    const provider = new ChromaProvider({ url: BASE_URL, collection: COLLECTION, embed });
+    const results = await provider.search('q');
+
+    expect(results[0]).toMatchObject({ id: 'doc1', text: 'Perfect match' });
+    expect(results[0].score).toBeCloseTo(1.0);    // 1/(1+0)
+    expect(results[0].metadata?.src).toBe('wiki');
+    expect(results[1]).toMatchObject({ id: 'doc2', text: 'Distant match' });
+    expect(results[1].score).toBeCloseTo(0.5);    // 1/(1+1)
+  });
+
+  it('filters by minScore', async () => {
+    withCollection(queryResponse([
+      { id: 'a', distance: 0.1, document: 'close' },
+      { id: 'b', distance: 5.0, document: 'far' },
+    ]));
+    const provider = new ChromaProvider({ url: BASE_URL, collection: COLLECTION, embed });
+    const results = await provider.search('q', { minScore: 0.5 });
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe('a');
+  });
+
+  it('passes where filter to query body', async () => {
+    withCollection(queryResponse([]));
+    const provider = new ChromaProvider({ url: BASE_URL, collection: COLLECTION, embed });
+    await provider.search('q', { filter: { category: 'docs' } });
+
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[1][1].body);
+    expect(body.where).toEqual({ category: 'docs' });
+  });
+
+  it('throws on non-2xx query response', async () => {
+    mockFetchSequence([
+      { body: { id: COLLECTION_ID } },
+      { body: { error: 'bad request' }, status: 400 },
+    ]);
+    const provider = new ChromaProvider({ url: BASE_URL, collection: COLLECTION, embed });
+    await expect(provider.search('q')).rejects.toThrow(/400/);
+  });
+
+  it('upserts correctly', async () => {
+    withCollection({});
+    const provider = new ChromaProvider({ url: BASE_URL, collection: COLLECTION, embed });
+    await provider.upsert('id1', 'hello world', { src: 'test' });
+
+    const upsertCall = (global.fetch as jest.Mock).mock.calls[1];
+    expect(upsertCall[0]).toBe(`${API_BASE}/${COLLECTION_ID}/upsert`);
+    const body = JSON.parse(upsertCall[1].body);
+    expect(body.ids).toEqual(['id1']);
+    expect(body.documents).toEqual(['hello world']);
+    expect(body.embeddings[0]).toEqual([0.1, 0.2, 0.3]);
+    expect(body.metadatas[0].src).toBe('test');
+  });
+
+  it('deletes correctly', async () => {
+    withCollection({});
+    const provider = new ChromaProvider({ url: BASE_URL, collection: COLLECTION, embed });
+    await provider.delete('id1');
+
+    const deleteCall = (global.fetch as jest.Mock).mock.calls[1];
+    expect(deleteCall[0]).toBe(`${API_BASE}/${COLLECTION_ID}/delete`);
+    expect(JSON.parse(deleteCall[1].body).ids).toEqual(['id1']);
+  });
+});
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function queryResponse(
+  items: Array<{ id: string; distance: number; document: string; metadata?: Record<string, unknown> | null }>,
+): { ids: string[][]; distances: number[][]; documents: Array<Array<string | null>>; metadatas: Array<Array<Record<string, unknown> | null>> } {
+  return {
+    ids: [items.map((i) => i.id)],
+    distances: [items.map((i) => i.distance)],
+    documents: [items.map((i) => i.document ?? null)],
+    metadatas: [items.map((i) => i.metadata ?? null)],
+  };
+}

--- a/packages/vector-chroma/jest.config.ts
+++ b/packages/vector-chroma/jest.config.ts
@@ -1,0 +1,3 @@
+import type { Config } from 'jest';
+const config: Config = { preset: 'ts-jest', testEnvironment: 'node', roots: ['<rootDir>/__tests__'], transform: { '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }] } };
+export default config;

--- a/packages/vector-chroma/package.json
+++ b/packages/vector-chroma/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@foxframework/vector-chroma",
+  "version": "1.0.0",
+  "description": "ChromaDB vector store provider for Fox Framework agents — native fetch, no SDK",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist/**/*", "package.json"],
+  "publishConfig": { "access": "public" },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "jest --config jest.config.ts --detectOpenHandles --forceExit"
+  },
+  "keywords": ["fox-framework", "chroma", "chromadb", "vector", "agents", "embeddings"],
+  "author": "Luis Navarro Carter",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/jest": "^29.5.8",
+    "@types/node": "^20.10.4",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.3.2"
+  }
+}

--- a/packages/vector-chroma/src/chroma.provider.ts
+++ b/packages/vector-chroma/src/chroma.provider.ts
@@ -1,0 +1,196 @@
+import type { IVectorSearchProvider, VectorSearchOptions, VectorSearchResult } from './types';
+
+export interface ChromaConfig {
+  /** ChromaDB server URL, e.g. "http://localhost:8000" */
+  url: string;
+  /** Collection name */
+  collection: string;
+  /** Optional tenant (default: "default_tenant") */
+  tenant?: string;
+  /** Optional database (default: "default_database") */
+  database?: string;
+  /** Optional API key / token for auth header */
+  apiKey?: string;
+  /**
+   * Embedding function — required for search and upsert.
+   * ChromaDB's REST API requires client-side embeddings when no server-side
+   * embedding function is configured.
+   */
+  embed?: (texts: string[]) => Promise<number[][]>;
+}
+
+interface ChromaQueryResponse {
+  ids: string[][];
+  distances: number[][];
+  metadatas: Array<Array<Record<string, unknown> | null>>;
+  documents: Array<Array<string | null>>;
+}
+
+/**
+ * ChromaProvider — implements IVectorSearchProvider against the ChromaDB REST API.
+ *
+ * Uses native `fetch` — no chromadb SDK required.
+ *
+ * @example
+ * ```ts
+ * const provider = new ChromaProvider({
+ *   url: 'http://localhost:8000',
+ *   collection: 'my-docs',
+ *   embed: async (texts) => myEmbedBatch(texts),
+ * });
+ * const tool = createVectorSearchTool(provider);
+ * ```
+ */
+export class ChromaProvider implements IVectorSearchProvider {
+  private readonly config: ChromaConfig;
+  private collectionId: string | null = null;
+
+  constructor(config: ChromaConfig) {
+    if (!config.url) throw new Error('ChromaProvider: url is required');
+    if (!config.collection) throw new Error('ChromaProvider: collection is required');
+    this.config = {
+      tenant: 'default_tenant',
+      database: 'default_database',
+      ...config,
+    };
+  }
+
+  private headers(): Record<string, string> {
+    const h: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.config.apiKey) h['Authorization'] = `Bearer ${this.config.apiKey}`;
+    return h;
+  }
+
+  private apiBase(): string {
+    const { url, tenant, database } = this.config;
+    return `${url}/api/v1/tenants/${tenant}/databases/${database}/collections`;
+  }
+
+  /** Lazily resolve the collection UUID from its name */
+  private async resolveCollectionId(): Promise<string> {
+    if (this.collectionId) return this.collectionId;
+
+    const response = await fetch(
+      `${this.apiBase()}/${encodeURIComponent(this.config.collection)}`,
+      { headers: this.headers() },
+    );
+
+    if (!response.ok) {
+      // Attempt to create if not found
+      if (response.status === 404) {
+        const create = await fetch(this.apiBase(), {
+          method: 'POST',
+          headers: this.headers(),
+          body: JSON.stringify({ name: this.config.collection }),
+        });
+        if (!create.ok) {
+          const err = await create.text();
+          throw new Error(`ChromaProvider: failed to create collection (${create.status}): ${err}`);
+        }
+        const created = (await create.json()) as { id: string };
+        this.collectionId = created.id;
+        return this.collectionId;
+      }
+      const text = await response.text();
+      throw new Error(`ChromaProvider: failed to get collection (${response.status}): ${text}`);
+    }
+
+    const col = (await response.json()) as { id: string };
+    this.collectionId = col.id;
+    return this.collectionId;
+  }
+
+  async search(query: string, options: VectorSearchOptions = {}): Promise<VectorSearchResult[]> {
+    if (!this.config.embed) {
+      throw new Error('ChromaProvider: embed function is required for search');
+    }
+
+    const topK = options.topK ?? 10;
+    const minScore = options.minScore ?? 0;
+    const collectionId = await this.resolveCollectionId();
+
+    const [queryEmbedding] = await this.config.embed([query]);
+
+    const body: Record<string, unknown> = {
+      query_embeddings: [queryEmbedding],
+      n_results: topK,
+      include: ['documents', 'metadatas', 'distances'],
+    };
+    if (options.filter && Object.keys(options.filter).length > 0) {
+      body.where = options.filter;
+    }
+
+    const response = await fetch(
+      `${this.apiBase()}/${collectionId}/query`,
+      { method: 'POST', headers: this.headers(), body: JSON.stringify(body) },
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`ChromaProvider: query failed (${response.status}): ${text}`);
+    }
+
+    const data = (await response.json()) as ChromaQueryResponse;
+    const ids = data.ids[0] ?? [];
+    const distances = data.distances[0] ?? [];
+    const metadatas = data.metadatas[0] ?? [];
+    const documents = data.documents[0] ?? [];
+
+    return ids
+      .map((id, i) => {
+        // Chroma returns L2 distance; convert to cosine-like score: 1 / (1 + distance)
+        const score = 1 / (1 + distances[i]);
+        return {
+          id,
+          score,
+          text: documents[i] ?? '',
+          metadata: metadatas[i] ?? undefined,
+        };
+      })
+      .filter((r) => r.score >= minScore);
+  }
+
+  async upsert(id: string, text: string, metadata: Record<string, unknown> = {}): Promise<void> {
+    if (!this.config.embed) {
+      throw new Error('ChromaProvider: embed function is required for upsert');
+    }
+
+    const collectionId = await this.resolveCollectionId();
+    const [embedding] = await this.config.embed([text]);
+
+    const body = {
+      ids: [id],
+      embeddings: [embedding],
+      documents: [text],
+      metadatas: [metadata],
+    };
+
+    const response = await fetch(
+      `${this.apiBase()}/${collectionId}/upsert`,
+      { method: 'POST', headers: this.headers(), body: JSON.stringify(body) },
+    );
+
+    if (!response.ok) {
+      const err = await response.text();
+      throw new Error(`ChromaProvider: upsert failed (${response.status}): ${err}`);
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    const collectionId = await this.resolveCollectionId();
+
+    const response = await fetch(
+      `${this.apiBase()}/${collectionId}/delete`,
+      {
+        method: 'POST',
+        headers: this.headers(),
+        body: JSON.stringify({ ids: [id] }),
+      },
+    );
+
+    if (!response.ok) {
+      const err = await response.text();
+      throw new Error(`ChromaProvider: delete failed (${response.status}): ${err}`);
+    }
+  }
+}

--- a/packages/vector-chroma/src/index.ts
+++ b/packages/vector-chroma/src/index.ts
@@ -1,0 +1,3 @@
+export type { IVectorSearchProvider, VectorSearchOptions, VectorSearchResult } from './types';
+export { ChromaProvider } from './chroma.provider';
+export type { ChromaConfig } from './chroma.provider';

--- a/packages/vector-chroma/src/types.ts
+++ b/packages/vector-chroma/src/types.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared vector store types — mirrored from tsfox/core/agents/tools/vector-search.tool.ts
+ * Kept here so each package has zero runtime deps on @foxframework/core.
+ */
+
+export interface VectorSearchOptions {
+  topK?: number;
+  minScore?: number;
+  filter?: Record<string, unknown>;
+  namespace?: string;
+}
+
+export interface VectorSearchResult {
+  id: string;
+  score: number;
+  text: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IVectorSearchProvider {
+  search(query: string, options?: VectorSearchOptions): Promise<VectorSearchResult[]>;
+  upsert?(id: string, text: string, metadata?: Record<string, unknown>): Promise<void>;
+  delete?(id: string): Promise<void>;
+}

--- a/packages/vector-chroma/tsconfig.build.json
+++ b/packages/vector-chroma/tsconfig.build.json
@@ -1,0 +1,1 @@
+{"extends":"../../tsconfig.json","compilerOptions":{"rootDir":"./src","outDir":"./dist","declaration":true,"declarationMap":true,"paths":{}},"include":["src/**/*"],"exclude":["node_modules","dist","**/*.test.ts"]}

--- a/packages/vector-chroma/tsconfig.json
+++ b/packages/vector-chroma/tsconfig.json
@@ -1,0 +1,1 @@
+{"extends":"../../tsconfig.json","compilerOptions":{"rootDir":".","outDir":"./dist-test","paths":{}},"include":["src/**/*","__tests__/**/*"],"exclude":["node_modules","dist"]}

--- a/packages/vector-pinecone/__tests__/pinecone.provider.test.ts
+++ b/packages/vector-pinecone/__tests__/pinecone.provider.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @foxframework/vector-pinecone — unit tests
+ * All HTTP calls are mocked via global.fetch.
+ */
+
+import { PineconeProvider } from '../src/pinecone.provider';
+
+const INDEX_HOST = 'https://test-index.svc.us-east1-gcp.pinecone.io';
+const API_KEY = 'test-api-key';
+
+function mockFetch(body: unknown, status = 200) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+    text: jest.fn().mockResolvedValue(JSON.stringify(body)),
+  }) as unknown as typeof fetch;
+}
+
+const embed = jest.fn().mockResolvedValue([0.1, 0.2, 0.3]);
+
+describe('PineconeProvider', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('throws if apiKey is missing', () => {
+    expect(() => new PineconeProvider({ apiKey: '', indexHost: INDEX_HOST })).toThrow(/apiKey/);
+  });
+
+  it('throws if indexHost is missing', () => {
+    expect(() => new PineconeProvider({ apiKey: API_KEY, indexHost: '' })).toThrow(/indexHost/);
+  });
+
+  it('throws on search without embed function', async () => {
+    const provider = new PineconeProvider({ apiKey: API_KEY, indexHost: INDEX_HOST });
+    await expect(provider.search('test')).rejects.toThrow(/embed function/);
+  });
+
+  it('queries the correct endpoint with vector and topK', async () => {
+    mockFetch({ matches: [] });
+    const provider = new PineconeProvider({ apiKey: API_KEY, indexHost: INDEX_HOST, embed });
+    await provider.search('hello', { topK: 5 });
+
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    expect(call[0]).toBe(`${INDEX_HOST}/query`);
+    const body = JSON.parse(call[1].body);
+    expect(body.topK).toBe(5);
+    expect(body.vector).toEqual([0.1, 0.2, 0.3]);
+    expect(call[1].headers['Api-Key']).toBe(API_KEY);
+  });
+
+  it('maps matches to VectorSearchResult', async () => {
+    mockFetch({
+      matches: [
+        { id: 'doc1', score: 0.95, metadata: { text: 'Fox Framework', source: 'wiki' } },
+        { id: 'doc2', score: 0.80, metadata: { text: 'Agent tools' } },
+      ],
+    });
+    const provider = new PineconeProvider({ apiKey: API_KEY, indexHost: INDEX_HOST, embed });
+    const results = await provider.search('fox');
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ id: 'doc1', score: 0.95, text: 'Fox Framework' });
+    expect(results[0].metadata?.source).toBe('wiki');
+    expect(results[1]).toMatchObject({ id: 'doc2', score: 0.80, text: 'Agent tools' });
+  });
+
+  it('filters results below minScore', async () => {
+    mockFetch({
+      matches: [
+        { id: 'a', score: 0.9, metadata: { text: 'high' } },
+        { id: 'b', score: 0.5, metadata: { text: 'low' } },
+      ],
+    });
+    const provider = new PineconeProvider({ apiKey: API_KEY, indexHost: INDEX_HOST, embed });
+    const results = await provider.search('q', { minScore: 0.7 });
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe('a');
+  });
+
+  it('sends namespace and filter when provided', async () => {
+    mockFetch({ matches: [] });
+    const provider = new PineconeProvider({ apiKey: API_KEY, indexHost: INDEX_HOST, embed });
+    await provider.search('q', { namespace: 'ns1', filter: { category: 'docs' } });
+
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.namespace).toBe('ns1');
+    expect(body.filter).toEqual({ category: 'docs' });
+  });
+
+  it('throws on non-2xx query response', async () => {
+    mockFetch({ message: 'Unauthorized' }, 401);
+    const provider = new PineconeProvider({ apiKey: API_KEY, indexHost: INDEX_HOST, embed });
+    await expect(provider.search('q')).rejects.toThrow(/401/);
+  });
+
+  it('upserts a vector', async () => {
+    mockFetch({ upsertedCount: 1 });
+    const provider = new PineconeProvider({ apiKey: API_KEY, indexHost: INDEX_HOST, embed });
+    await provider.upsert('doc1', 'hello world', { source: 'test' });
+
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    expect(call[0]).toBe(`${INDEX_HOST}/vectors/upsert`);
+    const body = JSON.parse(call[1].body);
+    expect(body.vectors[0].id).toBe('doc1');
+    expect(body.vectors[0].values).toEqual([0.1, 0.2, 0.3]);
+    expect(body.vectors[0].metadata.text).toBe('hello world');
+    expect(body.vectors[0].metadata.source).toBe('test');
+  });
+
+  it('deletes a vector', async () => {
+    mockFetch({});
+    const provider = new PineconeProvider({ apiKey: API_KEY, indexHost: INDEX_HOST, embed });
+    await provider.delete('doc1');
+
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    expect(call[0]).toBe(`${INDEX_HOST}/vectors/delete`);
+    expect(JSON.parse(call[1].body).ids).toEqual(['doc1']);
+  });
+});

--- a/packages/vector-pinecone/jest.config.ts
+++ b/packages/vector-pinecone/jest.config.ts
@@ -1,0 +1,3 @@
+import type { Config } from 'jest';
+const config: Config = { preset: 'ts-jest', testEnvironment: 'node', roots: ['<rootDir>/__tests__'], transform: { '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }] } };
+export default config;

--- a/packages/vector-pinecone/package.json
+++ b/packages/vector-pinecone/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@foxframework/vector-pinecone",
+  "version": "1.0.0",
+  "description": "Pinecone vector store provider for Fox Framework agents — native fetch, no SDK",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist/**/*", "package.json"],
+  "publishConfig": { "access": "public" },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "jest --config jest.config.ts --detectOpenHandles --forceExit"
+  },
+  "keywords": ["fox-framework", "pinecone", "vector", "agents", "embeddings"],
+  "author": "Luis Navarro Carter",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/jest": "^29.5.8",
+    "@types/node": "^20.10.4",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.3.2"
+  }
+}

--- a/packages/vector-pinecone/src/index.ts
+++ b/packages/vector-pinecone/src/index.ts
@@ -1,0 +1,3 @@
+export type { IVectorSearchProvider, VectorSearchOptions, VectorSearchResult } from './types';
+export { PineconeProvider } from './pinecone.provider';
+export type { PineconeConfig } from './pinecone.provider';

--- a/packages/vector-pinecone/src/pinecone.provider.ts
+++ b/packages/vector-pinecone/src/pinecone.provider.ts
@@ -1,0 +1,142 @@
+import type { IVectorSearchProvider, VectorSearchOptions, VectorSearchResult } from './types';
+
+export interface PineconeConfig {
+  /** Pinecone API key */
+  apiKey: string;
+  /**
+   * Full index host URL, e.g.
+   * "https://my-index-abc123.svc.us-east1-gcp.pinecone.io"
+   * Obtained from the Pinecone console after index creation.
+   */
+  indexHost: string;
+  /**
+   * Optional embedding function. If provided, `search` and `upsert` will use it
+   * to convert text → vector automatically.
+   * If omitted, you must pass `vector` directly (not yet exposed in this adapter).
+   */
+  embed?: (text: string) => Promise<number[]>;
+}
+
+interface PineconeMatch {
+  id: string;
+  score: number;
+  metadata?: Record<string, unknown>;
+}
+
+interface PineconeQueryResponse {
+  matches: PineconeMatch[];
+}
+
+interface PineconeUpsertVector {
+  id: string;
+  values: number[];
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * PineconeProvider — implements IVectorSearchProvider against the Pinecone REST API.
+ *
+ * Uses native `fetch` — no Pinecone SDK required.
+ *
+ * @example
+ * ```ts
+ * const provider = new PineconeProvider({
+ *   apiKey: process.env.PINECONE_API_KEY!,
+ *   indexHost: process.env.PINECONE_INDEX_HOST!,
+ *   embed: (text) => myEmbeddingFn(text),
+ * });
+ * const tool = createVectorSearchTool(provider);
+ * ```
+ */
+export class PineconeProvider implements IVectorSearchProvider {
+  private readonly config: PineconeConfig;
+
+  constructor(config: PineconeConfig) {
+    if (!config.apiKey) throw new Error('PineconeProvider: apiKey is required');
+    if (!config.indexHost) throw new Error('PineconeProvider: indexHost is required');
+    this.config = config;
+  }
+
+  async search(query: string, options: VectorSearchOptions = {}): Promise<VectorSearchResult[]> {
+    if (!this.config.embed) {
+      throw new Error('PineconeProvider: embed function is required for search');
+    }
+
+    const vector = await this.config.embed(query);
+    const topK = options.topK ?? 10;
+    const namespace = options.namespace;
+
+    const body: Record<string, unknown> = {
+      vector,
+      topK,
+      includeMetadata: true,
+    };
+    if (namespace) body.namespace = namespace;
+    if (options.filter) body.filter = options.filter;
+
+    const response = await fetch(`${this.config.indexHost}/query`, {
+      method: 'POST',
+      headers: {
+        'Api-Key': this.config.apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`PineconeProvider: query failed (${response.status}): ${text}`);
+    }
+
+    const data = (await response.json()) as PineconeQueryResponse;
+    const minScore = options.minScore ?? 0;
+
+    return data.matches
+      .filter((m) => m.score >= minScore)
+      .map((m) => ({
+        id: m.id,
+        score: m.score,
+        text: (m.metadata?.text as string) ?? m.id,
+        metadata: m.metadata,
+      }));
+  }
+
+  async upsert(id: string, text: string, metadata: Record<string, unknown> = {}): Promise<void> {
+    if (!this.config.embed) {
+      throw new Error('PineconeProvider: embed function is required for upsert');
+    }
+
+    const values = await this.config.embed(text);
+    const vector: PineconeUpsertVector = { id, values, metadata: { ...metadata, text } };
+
+    const response = await fetch(`${this.config.indexHost}/vectors/upsert`, {
+      method: 'POST',
+      headers: {
+        'Api-Key': this.config.apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ vectors: [vector] }),
+    });
+
+    if (!response.ok) {
+      const err = await response.text();
+      throw new Error(`PineconeProvider: upsert failed (${response.status}): ${err}`);
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    const response = await fetch(`${this.config.indexHost}/vectors/delete`, {
+      method: 'POST',
+      headers: {
+        'Api-Key': this.config.apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ ids: [id] }),
+    });
+
+    if (!response.ok) {
+      const err = await response.text();
+      throw new Error(`PineconeProvider: delete failed (${response.status}): ${err}`);
+    }
+  }
+}

--- a/packages/vector-pinecone/src/types.ts
+++ b/packages/vector-pinecone/src/types.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared vector store types — mirrored from tsfox/core/agents/tools/vector-search.tool.ts
+ * Kept here so each package has zero runtime deps on @foxframework/core.
+ */
+
+export interface VectorSearchOptions {
+  topK?: number;
+  minScore?: number;
+  filter?: Record<string, unknown>;
+  namespace?: string;
+}
+
+export interface VectorSearchResult {
+  id: string;
+  score: number;
+  text: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IVectorSearchProvider {
+  search(query: string, options?: VectorSearchOptions): Promise<VectorSearchResult[]>;
+  upsert?(id: string, text: string, metadata?: Record<string, unknown>): Promise<void>;
+  delete?(id: string): Promise<void>;
+}

--- a/packages/vector-pinecone/tsconfig.build.json
+++ b/packages/vector-pinecone/tsconfig.build.json
@@ -1,0 +1,1 @@
+{"extends":"../../tsconfig.json","compilerOptions":{"rootDir":"./src","outDir":"./dist","declaration":true,"declarationMap":true,"paths":{}},"include":["src/**/*"],"exclude":["node_modules","dist","**/*.test.ts"]}

--- a/packages/vector-pinecone/tsconfig.json
+++ b/packages/vector-pinecone/tsconfig.json
@@ -1,0 +1,1 @@
+{"extends":"../../tsconfig.json","compilerOptions":{"rootDir":".","outDir":"./dist-test","paths":{}},"include":["src/**/*","__tests__/**/*"],"exclude":["node_modules","dist"]}

--- a/packages/vector-weaviate/__tests__/weaviate.provider.test.ts
+++ b/packages/vector-weaviate/__tests__/weaviate.provider.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @foxframework/vector-weaviate — unit tests
+ * All HTTP calls are mocked via global.fetch.
+ */
+
+import { WeaviateProvider } from '../src/weaviate.provider';
+
+const URL = 'https://my-cluster.weaviate.network';
+const CLASS = 'Document';
+
+function mockFetch(body: unknown, status = 200) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+    text: jest.fn().mockResolvedValue(JSON.stringify(body)),
+  }) as unknown as typeof fetch;
+}
+
+function graphqlResponse(objects: unknown[]) {
+  return { data: { Get: { [CLASS]: objects } } };
+}
+
+const embed = jest.fn().mockResolvedValue([0.1, 0.2, 0.3]);
+
+describe('WeaviateProvider', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('throws if url is missing', () => {
+    expect(() => new WeaviateProvider({ url: '', className: CLASS })).toThrow(/url/);
+  });
+
+  it('throws if className is missing', () => {
+    expect(() => new WeaviateProvider({ url: URL, className: '' })).toThrow(/className/);
+  });
+
+  it('uses nearText when no embed fn is provided', async () => {
+    mockFetch(graphqlResponse([]));
+    const provider = new WeaviateProvider({ url: URL, className: CLASS });
+    await provider.search('fox framework');
+
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    expect(call[0]).toBe(`${URL}/v1/graphql`);
+    const gql: string = JSON.parse(call[1].body).query;
+    expect(gql).toContain('nearText');
+    expect(gql).toContain('fox framework');
+  });
+
+  it('uses nearVector when embed fn is provided', async () => {
+    mockFetch(graphqlResponse([]));
+    const provider = new WeaviateProvider({ url: URL, className: CLASS, embed });
+    await provider.search('test');
+
+    const gql: string = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body).query;
+    expect(gql).toContain('nearVector');
+  });
+
+  it('maps objects to VectorSearchResult', async () => {
+    mockFetch(
+      graphqlResponse([
+        { text: 'Fox Framework docs', _additional: { id: 'uuid-1', certainty: 0.92 } },
+        { text: 'Agent tools', _additional: { id: 'uuid-2', certainty: 0.75 } },
+      ]),
+    );
+    const provider = new WeaviateProvider({ url: URL, className: CLASS });
+    const results = await provider.search('q');
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ id: 'uuid-1', score: 0.92, text: 'Fox Framework docs' });
+    expect(results[1]).toMatchObject({ id: 'uuid-2', score: 0.75, text: 'Agent tools' });
+  });
+
+  it('uses distance when certainty is absent', async () => {
+    mockFetch(
+      graphqlResponse([
+        { text: 'result', _additional: { id: 'id1', distance: 0.2 } },
+      ]),
+    );
+    const provider = new WeaviateProvider({ url: URL, className: CLASS });
+    const [result] = await provider.search('q');
+    expect(result.score).toBeCloseTo(0.8);
+  });
+
+  it('sets Authorization header when apiKey is provided', async () => {
+    mockFetch(graphqlResponse([]));
+    const provider = new WeaviateProvider({ url: URL, className: CLASS, apiKey: 'secret' });
+    await provider.search('q');
+    const headers = (global.fetch as jest.Mock).mock.calls[0][1].headers;
+    expect(headers['Authorization']).toBe('Bearer secret');
+  });
+
+  it('throws on GraphQL errors', async () => {
+    mockFetch({ errors: [{ message: 'class not found' }] });
+    const provider = new WeaviateProvider({ url: URL, className: CLASS });
+    await expect(provider.search('q')).rejects.toThrow(/class not found/);
+  });
+
+  it('throws on non-2xx HTTP status', async () => {
+    mockFetch({}, 500);
+    const provider = new WeaviateProvider({ url: URL, className: CLASS });
+    await expect(provider.search('q')).rejects.toThrow(/500/);
+  });
+
+  it('upserts an object (POST)', async () => {
+    mockFetch({ id: 'new-id' }, 200);
+    const provider = new WeaviateProvider({ url: URL, className: CLASS });
+    await provider.upsert('id1', 'hello world', { source: 'test' });
+
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    expect(call[0]).toBe(`${URL}/v1/objects`);
+    const body = JSON.parse(call[1].body);
+    expect(body.class).toBe(CLASS);
+    expect(body.id).toBe('id1');
+    expect(body.properties.text).toBe('hello world');
+    expect(body.properties.source).toBe('test');
+  });
+
+  it('retries upsert with PUT on 409 conflict', async () => {
+    // First call → 409, second call (PUT) → 200
+    (global.fetch as jest.Mock) = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 409, text: jest.fn().mockResolvedValue('') })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: jest.fn().mockResolvedValue({}) });
+
+    const provider = new WeaviateProvider({ url: URL, className: CLASS });
+    await provider.upsert('id1', 'hello');
+
+    expect((global.fetch as jest.Mock)).toHaveBeenCalledTimes(2);
+    expect((global.fetch as jest.Mock).mock.calls[1][1].method).toBe('PUT');
+  });
+
+  it('deletes an object', async () => {
+    mockFetch(null, 204);
+    const provider = new WeaviateProvider({ url: URL, className: CLASS });
+    await provider.delete('id1');
+
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    expect(call[0]).toBe(`${URL}/v1/objects/${CLASS}/id1`);
+    expect(call[1].method).toBe('DELETE');
+  });
+});

--- a/packages/vector-weaviate/jest.config.ts
+++ b/packages/vector-weaviate/jest.config.ts
@@ -1,0 +1,3 @@
+import type { Config } from 'jest';
+const config: Config = { preset: 'ts-jest', testEnvironment: 'node', roots: ['<rootDir>/__tests__'], transform: { '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }] } };
+export default config;

--- a/packages/vector-weaviate/package.json
+++ b/packages/vector-weaviate/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@foxframework/vector-weaviate",
+  "version": "1.0.0",
+  "description": "Weaviate vector store provider for Fox Framework agents — native fetch, no SDK",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist/**/*", "package.json"],
+  "publishConfig": { "access": "public" },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "jest --config jest.config.ts --detectOpenHandles --forceExit"
+  },
+  "keywords": ["fox-framework", "weaviate", "vector", "agents", "embeddings"],
+  "author": "Luis Navarro Carter",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/jest": "^29.5.8",
+    "@types/node": "^20.10.4",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.3.2"
+  }
+}

--- a/packages/vector-weaviate/src/index.ts
+++ b/packages/vector-weaviate/src/index.ts
@@ -1,0 +1,3 @@
+export type { IVectorSearchProvider, VectorSearchOptions, VectorSearchResult } from './types';
+export { WeaviateProvider } from './weaviate.provider';
+export type { WeaviateConfig } from './weaviate.provider';

--- a/packages/vector-weaviate/src/types.ts
+++ b/packages/vector-weaviate/src/types.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared vector store types — mirrored from tsfox/core/agents/tools/vector-search.tool.ts
+ * Kept here so each package has zero runtime deps on @foxframework/core.
+ */
+
+export interface VectorSearchOptions {
+  topK?: number;
+  minScore?: number;
+  filter?: Record<string, unknown>;
+  namespace?: string;
+}
+
+export interface VectorSearchResult {
+  id: string;
+  score: number;
+  text: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IVectorSearchProvider {
+  search(query: string, options?: VectorSearchOptions): Promise<VectorSearchResult[]>;
+  upsert?(id: string, text: string, metadata?: Record<string, unknown>): Promise<void>;
+  delete?(id: string): Promise<void>;
+}

--- a/packages/vector-weaviate/src/weaviate.provider.ts
+++ b/packages/vector-weaviate/src/weaviate.provider.ts
@@ -1,0 +1,172 @@
+import type { IVectorSearchProvider, VectorSearchOptions, VectorSearchResult } from './types';
+
+export interface WeaviateConfig {
+  /** Weaviate instance URL, e.g. "https://my-cluster.weaviate.network" */
+  url: string;
+  /** Class/collection name to search in, e.g. "Document" */
+  className: string;
+  /** Optional API key (Weaviate Cloud) */
+  apiKey?: string;
+  /** Text property that holds the document content (default: "text") */
+  textProperty?: string;
+  /**
+   * Optional embedding function for nearText + upsert.
+   * If omitted, uses Weaviate's built-in vectorizer (nearText via concepts).
+   */
+  embed?: (text: string) => Promise<number[]>;
+}
+
+/**
+ * Weaviate GraphQL returns properties at the TOP LEVEL of each object
+ * alongside `_additional`. There is no nested `properties` wrapper.
+ */
+type WeaviateObject = Record<string, unknown> & {
+  _additional?: { id: string; certainty?: number; distance?: number };
+};
+
+interface WeaviateGraphQLResponse {
+  data?: {
+    Get?: Record<string, WeaviateObject[]>;
+  };
+  errors?: Array<{ message: string }>;
+}
+
+/**
+ * WeaviateProvider — implements IVectorSearchProvider against the Weaviate GraphQL API.
+ *
+ * Uses native `fetch` — no Weaviate SDK required.
+ *
+ * @example
+ * ```ts
+ * const provider = new WeaviateProvider({
+ *   url: process.env.WEAVIATE_URL!,
+ *   className: 'Document',
+ *   apiKey: process.env.WEAVIATE_API_KEY,
+ * });
+ * const tool = createVectorSearchTool(provider);
+ * ```
+ */
+export class WeaviateProvider implements IVectorSearchProvider {
+  private readonly config: Required<Pick<WeaviateConfig, 'url' | 'className' | 'textProperty'>> &
+    Omit<WeaviateConfig, 'url' | 'className' | 'textProperty'>;
+
+  constructor(config: WeaviateConfig) {
+    if (!config.url) throw new Error('WeaviateProvider: url is required');
+    if (!config.className) throw new Error('WeaviateProvider: className is required');
+    this.config = { ...config, textProperty: config.textProperty ?? 'text' };
+  }
+
+  private headers(): Record<string, string> {
+    const h: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.config.apiKey) h['Authorization'] = `Bearer ${this.config.apiKey}`;
+    return h;
+  }
+
+  async search(query: string, options: VectorSearchOptions = {}): Promise<VectorSearchResult[]> {
+    const topK = options.topK ?? 10;
+    const minScore = options.minScore ?? 0;
+    const { className, textProperty } = this.config;
+
+    // If embed fn is provided, use nearVector; otherwise use nearText (built-in vectorizer)
+    let nearClause: string;
+    if (this.config.embed) {
+      const vector = await this.config.embed(query);
+      nearClause = `nearVector: { vector: [${vector.join(',')}], certainty: ${minScore} }`;
+    } else {
+      nearClause = `nearText: { concepts: [${JSON.stringify(query)}], certainty: ${minScore} }`;
+    }
+
+    const whereClause =
+      options.filter && Object.keys(options.filter).length > 0
+        ? `, where: ${JSON.stringify(options.filter)}`
+        : '';
+
+    const gql = `{
+      Get {
+        ${className}(limit: ${topK}, ${nearClause}${whereClause}) {
+          ${textProperty}
+          _additional { id certainty distance }
+        }
+      }
+    }`;
+
+    const response = await fetch(`${this.config.url}/v1/graphql`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify({ query: gql }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`WeaviateProvider: search failed (${response.status}): ${text}`);
+    }
+
+    const data = (await response.json()) as WeaviateGraphQLResponse;
+    if (data.errors?.length) {
+      throw new Error(`WeaviateProvider: GraphQL error — ${data.errors[0].message}`);
+    }
+
+    const objects = data.data?.Get?.[className] ?? [];
+    return objects.map((obj) => {
+      const additional = obj._additional;
+      const certainty = additional?.certainty ?? 1 - (additional?.distance ?? 0);
+      const { _additional, [textProperty]: rawText, ...rest } = obj;
+      return {
+        id: additional?.id ?? '',
+        score: certainty,
+        text: (rawText as string) ?? '',
+        metadata: rest as Record<string, unknown>,
+      };
+    });
+  }
+
+  async upsert(id: string, text: string, metadata: Record<string, unknown> = {}): Promise<void> {
+    const { className, textProperty } = this.config;
+    const properties: Record<string, unknown> = { ...metadata, [textProperty]: text };
+
+    const body: Record<string, unknown> = {
+      class: className,
+      id,
+      properties,
+    };
+
+    if (this.config.embed) {
+      body.vector = await this.config.embed(text);
+    }
+
+    const response = await fetch(`${this.config.url}/v1/objects`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok && response.status !== 200) {
+      // 409 = already exists → try PUT
+      if (response.status === 409) {
+        const put = await fetch(`${this.config.url}/v1/objects/${className}/${id}`, {
+          method: 'PUT',
+          headers: this.headers(),
+          body: JSON.stringify(body),
+        });
+        if (!put.ok) {
+          const err = await put.text();
+          throw new Error(`WeaviateProvider: upsert (PUT) failed (${put.status}): ${err}`);
+        }
+        return;
+      }
+      const err = await response.text();
+      throw new Error(`WeaviateProvider: upsert failed (${response.status}): ${err}`);
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    const response = await fetch(
+      `${this.config.url}/v1/objects/${this.config.className}/${id}`,
+      { method: 'DELETE', headers: this.headers() },
+    );
+    if (!response.ok && response.status !== 204) {
+      const err = await response.text();
+      throw new Error(`WeaviateProvider: delete failed (${response.status}): ${err}`);
+    }
+  }
+}

--- a/packages/vector-weaviate/tsconfig.build.json
+++ b/packages/vector-weaviate/tsconfig.build.json
@@ -1,0 +1,1 @@
+{"extends":"../../tsconfig.json","compilerOptions":{"rootDir":"./src","outDir":"./dist","declaration":true,"declarationMap":true,"paths":{}},"include":["src/**/*"],"exclude":["node_modules","dist","**/*.test.ts"]}

--- a/packages/vector-weaviate/tsconfig.json
+++ b/packages/vector-weaviate/tsconfig.json
@@ -1,0 +1,1 @@
+{"extends":"../../tsconfig.json","compilerOptions":{"rootDir":".","outDir":"./dist-test","paths":{}},"include":["src/**/*","__tests__/**/*"],"exclude":["node_modules","dist"]}

--- a/tsfox/core/agents/__tests__/epic-d1.test.ts
+++ b/tsfox/core/agents/__tests__/epic-d1.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Epic D1 — Agent Tools Library
+ * Tests for: HttpTool, FilesystemTool, CalculatorTool, JsonPathTool, SqlQueryTool, VectorSearchTool
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+
+import { HttpTool } from '../tools/http.tool';
+import { FilesystemTool, createFilesystemTool } from '../tools/filesystem.tool';
+import { CalculatorTool } from '../tools/calculator.tool';
+import { JsonPathTool } from '../tools/jsonpath.tool';
+import { createSqlQueryTool, IQueryExecutor } from '../tools/sql-query.tool';
+import {
+  createVectorSearchTool,
+  IVectorSearchProvider,
+  VectorSearchResult,
+} from '../tools/vector-search.tool';
+
+// ─── HttpTool ─────────────────────────────────────────────────────────────────
+
+describe('HttpTool', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  function mockFetch(body: string, status = 200, contentType = 'application/json') {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 200 ? 'OK' : 'Error',
+      headers: { get: () => contentType },
+      text: async () => body,
+    }) as unknown as typeof fetch;
+  }
+
+  it('has correct name and required parameter', () => {
+    expect(HttpTool.definition.name).toBe('http');
+    expect(HttpTool.definition.parameters.required).toContain('url');
+  });
+
+  it('makes a GET request and returns JSON response', async () => {
+    mockFetch(JSON.stringify({ message: 'hello' }));
+    const result = await HttpTool.execute({ url: 'https://api.example.com/test' }, {} as any);
+    expect(result).toContain('"message"');
+    expect(result).toContain('"hello"');
+  });
+
+  it('returns HTTP error status for non-2xx', async () => {
+    mockFetch('Not Found', 404, 'text/plain');
+    const result = await HttpTool.execute({ url: 'https://api.example.com/missing' }, {} as any);
+    expect(result).toMatch(/HTTP 404/);
+  });
+
+  it('throws on invalid URL', async () => {
+    await expect(HttpTool.execute({ url: 'ftp://invalid' }, {} as any)).rejects.toThrow(
+      /invalid URL/,
+    );
+  });
+
+  it('sends POST with body and sets Content-Type', async () => {
+    mockFetch('{"ok":true}');
+    await HttpTool.execute({
+      url: 'https://api.example.com/data',
+      method: 'POST',
+      body: { key: 'value' },
+    }, {} as any);
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    expect(call[1].method).toBe('POST');
+    expect(call[1].headers['Content-Type']).toBe('application/json');
+    expect(call[1].body).toBe('{"key":"value"}');
+  });
+
+  it('times out and throws AbortError-style error', async () => {
+    global.fetch = jest.fn().mockImplementation(() => {
+      return new Promise((_, reject) => {
+        setTimeout(() => {
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        }, 10);
+      });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      HttpTool.execute({ url: 'https://api.example.com/slow', timeout: 1 }, {} as any),
+    ).rejects.toThrow(/timed out/);
+  });
+
+  it('returns plain text for non-JSON responses', async () => {
+    mockFetch('<html>page</html>', 200, 'text/html');
+    const result = await HttpTool.execute({ url: 'https://example.com' }, {} as any);
+    expect(result).toContain('<html>');
+  });
+});
+
+// ─── FilesystemTool ───────────────────────────────────────────────────────────
+
+describe('FilesystemTool', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fox-fs-tool-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes and reads a file', async () => {
+    const filePath = path.join(tmpDir, 'hello.txt');
+    await FilesystemTool.execute({ operation: 'write', path: filePath, content: 'hello world' }, {} as any);
+    const result = await FilesystemTool.execute({ operation: 'read', path: filePath }, {} as any);
+    expect(result).toContain('hello world');
+  });
+
+  it('appends to a file', async () => {
+    const filePath = path.join(tmpDir, 'append.txt');
+    await FilesystemTool.execute({ operation: 'write', path: filePath, content: 'line1\n' }, {} as any);
+    await FilesystemTool.execute({ operation: 'append', path: filePath, content: 'line2\n' }, {} as any);
+    const result = await FilesystemTool.execute({ operation: 'read', path: filePath }, {} as any);
+    expect(result).toContain('line1');
+    expect(result).toContain('line2');
+  });
+
+  it('lists directory contents', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'a.txt'), 'a');
+    fs.writeFileSync(path.join(tmpDir, 'b.txt'), 'b');
+    const result = await FilesystemTool.execute({ operation: 'list', path: tmpDir }, {} as any);
+    expect(result).toContain('a.txt');
+    expect(result).toContain('b.txt');
+  });
+
+  it('checks if file exists', async () => {
+    const filePath = path.join(tmpDir, 'exists.txt');
+    let result = await FilesystemTool.execute({ operation: 'exists', path: filePath }, {} as any);
+    expect(result).toContain('not found');
+    fs.writeFileSync(filePath, 'x');
+    result = await FilesystemTool.execute({ operation: 'exists', path: filePath }, {} as any);
+    expect(result).toContain('file');
+  });
+
+  it('deletes a file', async () => {
+    const filePath = path.join(tmpDir, 'del.txt');
+    fs.writeFileSync(filePath, 'bye');
+    await FilesystemTool.execute({ operation: 'delete', path: filePath }, {} as any);
+    expect(fs.existsSync(filePath)).toBe(false);
+  });
+
+  it('creates a directory', async () => {
+    const dirPath = path.join(tmpDir, 'nested', 'dir');
+    await FilesystemTool.execute({ operation: 'mkdir', path: dirPath }, {} as any);
+    expect(fs.existsSync(dirPath)).toBe(true);
+  });
+
+  it('enforces allowedBase restriction', async () => {
+    const restricted = createFilesystemTool({ allowedBase: tmpDir });
+    await expect(
+      restricted.execute({ operation: 'read', path: '/etc/passwd' }, {} as any),
+    ).rejects.toThrow(/outside allowed base/);
+  });
+
+  it('throws when reading non-existent file', async () => {
+    await expect(
+      FilesystemTool.execute({ operation: 'read', path: path.join(tmpDir, 'nope.txt') }, {} as any),
+    ).rejects.toThrow(/not found/);
+  });
+});
+
+// ─── CalculatorTool ───────────────────────────────────────────────────────────
+
+describe('CalculatorTool', () => {
+  async function calc(expression: string): Promise<string> {
+    return CalculatorTool.execute({ expression }, {} as any) as Promise<string>;
+  }
+
+  it('evaluates basic arithmetic', async () => {
+    expect(await calc('2 + 3')).toBe('2 + 3 = 5');
+    expect(await calc('10 - 4')).toBe('10 - 4 = 6');
+    expect(await calc('3 * 7')).toBe('3 * 7 = 21');
+    expect(await calc('15 / 4')).toBe('15 / 4 = 3.75');
+  });
+
+  it('evaluates exponentiation', async () => {
+    expect(await calc('2 ** 8')).toBe('2 ** 8 = 256');
+    expect(await calc('3 ** 3')).toBe('3 ** 3 = 27');
+  });
+
+  it('evaluates modulo', async () => {
+    expect(await calc('17 % 5')).toBe('17 % 5 = 2');
+  });
+
+  it('handles parentheses and operator precedence', async () => {
+    expect(await calc('(2 + 3) * 4')).toBe('(2 + 3) * 4 = 20');
+    expect(await calc('2 + 3 * 4')).toBe('2 + 3 * 4 = 14');
+  });
+
+  it('handles math functions', async () => {
+    const r = await calc('sqrt(144)');
+    expect(r).toBe('sqrt(144) = 12');
+    const r2 = await calc('abs(-42)');
+    expect(r2).toBe('abs(-42) = 42');
+  });
+
+  it('handles math constants', async () => {
+    const r = await calc('PI');
+    expect(r).toContain('3.14159');
+  });
+
+  it('handles negative numbers', async () => {
+    expect(await calc('-5 + 3')).toBe('-5 + 3 = -2');
+  });
+
+  it('throws on division by zero', async () => {
+    await expect(calc('10 / 0')).rejects.toThrow(/division by zero/);
+  });
+
+  it('throws on unknown identifiers', async () => {
+    await expect(calc('foo + 1')).rejects.toThrow(/unknown identifier/);
+  });
+
+  it('handles chained exponentiation (right-assoc)', async () => {
+    // 2**3**2 = 2**(3**2) = 2**9 = 512
+    const r = await calc('2 ** 3 ** 2');
+    expect(r).toBe('2 ** 3 ** 2 = 512');
+  });
+});
+
+// ─── JsonPathTool ─────────────────────────────────────────────────────────────
+
+describe('JsonPathTool', () => {
+  const sample = JSON.stringify({
+    users: [
+      { name: 'Alice', age: 30, roles: ['admin', 'user'] },
+      { name: 'Bob', age: 25, roles: ['user'] },
+    ],
+    meta: { total: 2, page: 1 },
+  });
+
+  async function query(json: string, path: string, operation?: string): Promise<string> {
+    return JsonPathTool.execute({ json, path, operation }, {} as any) as Promise<string>;
+  }
+
+  it('gets a nested field', async () => {
+    const result = await query(sample, '.meta.total');
+    expect(result).toBe('2');
+  });
+
+  it('gets an array element', async () => {
+    const result = await query(sample, '.users[0].name');
+    expect(result).toBe('"Alice"');
+  });
+
+  it('gets all values with .*', async () => {
+    const result = await query(sample, '.meta.*');
+    expect(result).toContain('2');
+    expect(result).toContain('1');
+  });
+
+  it('counts array elements', async () => {
+    const result = await query(sample, '.users', 'count');
+    expect(result).toBe('2');
+  });
+
+  it('lists keys of an object', async () => {
+    const result = await query(sample, '.meta', 'keys');
+    expect(result).toContain('total');
+    expect(result).toContain('page');
+  });
+
+  it('flattens nested arrays', async () => {
+    const json = JSON.stringify([[1, 2], [3, [4, 5]]]);
+    const result = await query(json, '.', 'flatten');
+    const parsed = JSON.parse(result);
+    expect(parsed).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('returns root with "." path', async () => {
+    const result = await query('{"a":1}', '.');
+    expect(JSON.parse(result)).toEqual({ a: 1 });
+  });
+
+  it('throws on invalid JSON', async () => {
+    await expect(query('not json', '.')).rejects.toThrow(/invalid JSON/);
+  });
+});
+
+// ─── SqlQueryTool ─────────────────────────────────────────────────────────────
+
+describe('SqlQueryTool', () => {
+  function makeExecutor(rows: unknown[], rowCount?: number): IQueryExecutor {
+    return {
+      query: jest.fn().mockResolvedValue({ rows, rowCount: rowCount ?? rows.length }),
+    };
+  }
+
+  it('returns a markdown table for SELECT results', async () => {
+    const executor = makeExecutor([
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+    ]);
+    const tool = createSqlQueryTool(executor);
+    const result = await tool.execute({ sql: 'SELECT * FROM users' }, {} as any);
+    expect(result).toContain('| id | name |');
+    expect(result).toContain('| 1 | Alice |');
+    expect(result).toContain('| 2 | Bob |');
+  });
+
+  it('returns "0 rows" message for empty results', async () => {
+    const executor = makeExecutor([]);
+    const tool = createSqlQueryTool(executor);
+    const result = await tool.execute({ sql: 'SELECT * FROM empty' }, {} as any);
+    expect(result).toContain('0 rows');
+  });
+
+  it('blocks mutation statements by default', async () => {
+    const executor = makeExecutor([]);
+    const tool = createSqlQueryTool(executor);
+    await expect(
+      tool.execute({ sql: 'DELETE FROM users WHERE id = 1' }, {} as any),
+    ).rejects.toThrow(/mutation statements are not allowed/);
+  });
+
+  it('allows mutations when configured', async () => {
+    const executor = makeExecutor([], 1);
+    const tool = createSqlQueryTool(executor, { allowMutations: true });
+    const result = await tool.execute({ sql: 'DELETE FROM users WHERE id = 1' }, {} as any);
+    expect(result).toContain('0 rows');
+  });
+
+  it('truncates results at maxRows', async () => {
+    const rows = Array.from({ length: 150 }, (_, i) => ({ id: i }));
+    const executor = makeExecutor(rows);
+    const tool = createSqlQueryTool(executor, { maxRows: 10 });
+    const result = await tool.execute({ sql: 'SELECT * FROM big' }, {} as any);
+    expect(result).toContain('truncated to 10 rows');
+  });
+
+  it('passes params to executor', async () => {
+    const executor = makeExecutor([{ id: 5 }]);
+    const tool = createSqlQueryTool(executor);
+    await tool.execute({ sql: 'SELECT * FROM users WHERE id = $1', params: [5] }, {} as any);
+    expect((executor.query as jest.Mock).mock.calls[0][1]).toEqual([5]);
+  });
+});
+
+// ─── VectorSearchTool ─────────────────────────────────────────────────────────
+
+describe('VectorSearchTool', () => {
+  function makeProvider(results: VectorSearchResult[]): IVectorSearchProvider {
+    return {
+      search: jest.fn().mockResolvedValue(results),
+    };
+  }
+
+  it('returns formatted results', async () => {
+    const provider = makeProvider([
+      { id: '1', score: 0.95, text: 'Fox Framework is a TypeScript web framework.' },
+      { id: '2', score: 0.88, text: 'It supports agents and LLMs natively.' },
+    ]);
+    const tool = createVectorSearchTool(provider);
+    const result = await tool.execute({ query: 'what is fox framework' }, {} as any);
+    expect(result).toContain('0.9500');
+    expect(result).toContain('Fox Framework');
+    expect(result).toContain('0.8800');
+  });
+
+  it('returns "no results" message when empty', async () => {
+    const provider = makeProvider([]);
+    const tool = createVectorSearchTool(provider);
+    const result = await tool.execute({ query: 'nothing' }, {} as any);
+    expect(result).toContain('No results found');
+  });
+
+  it('passes topK and minScore to provider', async () => {
+    const provider = makeProvider([]);
+    const tool = createVectorSearchTool(provider);
+    await tool.execute({ query: 'test', top_k: 3, min_score: 0.7 }, {} as any);
+    expect((provider.search as jest.Mock).mock.calls[0][1]).toMatchObject({
+      topK: 3,
+      minScore: 0.7,
+    });
+  });
+
+  it('includes metadata in output', async () => {
+    const provider = makeProvider([
+      { id: '1', score: 0.9, text: 'result', metadata: { source: 'wiki', year: 2024 } },
+    ]);
+    const tool = createVectorSearchTool(provider);
+    const result = await tool.execute({ query: 'test' }, {} as any);
+    expect(result).toContain('source=wiki');
+    expect(result).toContain('year=2024');
+  });
+
+  it('uses custom label and description', async () => {
+    const provider = makeProvider([]);
+    const tool = createVectorSearchTool(provider, {
+      label: 'knowledge_base',
+      description: 'Search the KB',
+    });
+    expect(tool.definition.name).toBe('knowledge_base');
+    expect(tool.definition.description).toBe('Search the KB');
+  });
+});

--- a/tsfox/core/agents/__tests__/epic-d3.test.ts
+++ b/tsfox/core/agents/__tests__/epic-d3.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Epic D3 — Streaming UI
+ * Tests for: SseStream, AgentSseEmitter, createAgentSseHandler
+ */
+
+import { SseStream } from '../streaming/sse-stream';
+import { AgentSseEmitter } from '../streaming/agent-sse-emitter';
+import { createAgentSseHandler } from '../streaming/create-agent-sse-handler';
+import type {
+  IAgent,
+  AgentRunResult,
+  AgentStatus,
+} from '../interfaces/agent.interface';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRes() {
+  const chunks: string[] = [];
+  return {
+    headersSent: false,
+    writableEnded: false,
+    headers: {} as Record<string, string>,
+    setHeader(name: string, value: string) { this.headers[name] = value; },
+    write(chunk: string) { chunks.push(chunk); return true; },
+    end() { this.writableEnded = true; },
+    get output() { return chunks.join(''); },
+    get events(): Array<{ event: string; data: unknown; id?: string }> {
+      return parseSSE(chunks.join(''));
+    },
+  };
+}
+
+function parseSSE(raw: string): Array<{ event: string; data: unknown; id?: string }> {
+  const results: Array<{ event: string; data: unknown; id?: string }> = [];
+  const blocks = raw.split('\n\n').filter(Boolean);
+  for (const block of blocks) {
+    const lines = block.split('\n');
+    let event = '';
+    let dataLines: string[] = [];
+    let id: string | undefined;
+    for (const line of lines) {
+      if (line.startsWith('event: ')) event = line.slice(7);
+      else if (line.startsWith('data: ')) dataLines.push(line.slice(6));
+      else if (line.startsWith('id: ')) id = line.slice(4);
+    }
+    if (event) {
+      try {
+        const parsed = JSON.parse(dataLines.join('\n'));
+        results.push({ event, data: parsed, ...(id ? { id } : {}) });
+      } catch {
+        results.push({ event, data: dataLines.join('\n'), ...(id ? { id } : {}) });
+      }
+    }
+  }
+  return results;
+}
+
+function makeAgent(result: Partial<AgentRunResult> = {}): IAgent {
+  const run: AgentRunResult = {
+    runId: 'run-1',
+    answer: 'The answer is 42.',
+    steps: [
+      {
+        stepNumber: 1,
+        type: 'thought',
+        content: 'I need to think...',
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+      },
+      {
+        stepNumber: 2,
+        type: 'final_answer',
+        content: 'The answer is 42.',
+        timestamp: new Date('2024-01-01T00:00:01Z'),
+      },
+    ],
+    status: 'completed',
+    usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
+    ...result,
+  };
+
+  return {
+    id: 'agent-1',
+    name: 'TestAgent',
+    get status(): AgentStatus { return 'idle'; },
+    run: jest.fn().mockResolvedValue(run),
+    abort: jest.fn(),
+  };
+}
+
+// ─── SseStream ────────────────────────────────────────────────────────────────
+
+describe('SseStream', () => {
+  it('sets SSE headers on construction', () => {
+    const res = makeRes();
+    new SseStream(res);
+    expect(res.headers['Content-Type']).toBe('text/event-stream');
+    expect(res.headers['Cache-Control']).toBe('no-cache');
+  });
+
+  it('writes event and data lines', () => {
+    const res = makeRes();
+    const sse = new SseStream(res);
+    sse.send({ event: 'step', data: { msg: 'hello' } });
+
+    expect(res.output).toContain('event: step');
+    expect(res.output).toContain('data: {"msg":"hello"}');
+    expect(res.output).toContain('\n\n');
+  });
+
+  it('includes id when provided', () => {
+    const res = makeRes();
+    const sse = new SseStream(res);
+    sse.send({ event: 'step', data: {}, id: 42 });
+    expect(res.output).toContain('id: 42');
+  });
+
+  it('calls res.end() on close()', () => {
+    const res = makeRes();
+    const sse = new SseStream(res);
+    sse.close();
+    expect(res.writableEnded).toBe(true);
+    expect(sse.closed).toBe(true);
+  });
+
+  it('silently ignores send() after close()', () => {
+    const res = makeRes();
+    const sse = new SseStream(res);
+    sse.close();
+    const before = res.output;
+    sse.send({ event: 'late', data: {} });
+    expect(res.output).toBe(before);
+  });
+
+  it('silently ignores double close()', () => {
+    const res = makeRes();
+    const sse = new SseStream(res);
+    sse.close();
+    expect(() => sse.close()).not.toThrow();
+  });
+
+  it('uses writeHead when available', () => {
+    const res = makeRes() as ReturnType<typeof makeRes> & { writeHead?: jest.Mock };
+    res.writeHead = jest.fn();
+    new SseStream(res);
+    expect(res.writeHead).toHaveBeenCalledWith(200, expect.objectContaining({ 'Content-Type': 'text/event-stream' }));
+  });
+
+  it('handles multi-line JSON (no control chars break SSE)', () => {
+    const res = makeRes();
+    const sse = new SseStream(res);
+    sse.send({ event: 'data', data: { a: 1, b: 2 } });
+    // Each line of the JSON must be prefixed with "data: "
+    const lines = res.output.split('\n').filter((l) => l.includes('{') || l.includes('}'));
+    for (const line of lines) {
+      expect(line.startsWith('data: ')).toBe(true);
+    }
+  });
+});
+
+// ─── AgentSseEmitter ──────────────────────────────────────────────────────────
+
+describe('AgentSseEmitter', () => {
+  it('emits a step event for each agent step', async () => {
+    const res = makeRes();
+    const agent = makeAgent();
+    const emitter = new AgentSseEmitter(agent, res, { heartbeatIntervalMs: 0 });
+    await emitter.run('What is 6 * 7?');
+
+    const stepEvents = res.events.filter((e) => e.event === 'step');
+    expect(stepEvents).toHaveLength(2);
+    expect((stepEvents[0].data as any).type).toBe('thought');
+    expect((stepEvents[1].data as any).type).toBe('final_answer');
+  });
+
+  it('emits a done event with answer and usage', async () => {
+    const res = makeRes();
+    const emitter = new AgentSseEmitter(makeAgent(), res, { heartbeatIntervalMs: 0 });
+    await emitter.run('test');
+
+    const done = res.events.find((e) => e.event === 'done');
+    expect(done).toBeDefined();
+    expect((done!.data as any).answer).toBe('The answer is 42.');
+    expect((done!.data as any).status).toBe('completed');
+    expect((done!.data as any).usage.totalTokens).toBe(150);
+  });
+
+  it('closes the SSE stream after run', async () => {
+    const res = makeRes();
+    const emitter = new AgentSseEmitter(makeAgent(), res, { heartbeatIntervalMs: 0 });
+    await emitter.run('test');
+    expect(res.writableEnded).toBe(true);
+  });
+
+  it('emits error event and rethrows on agent failure', async () => {
+    const agent = makeAgent();
+    (agent.run as jest.Mock).mockRejectedValue(new Error('agent exploded'));
+
+    const res = makeRes();
+    const emitter = new AgentSseEmitter(agent, res, { heartbeatIntervalMs: 0 });
+
+    await expect(emitter.run('test')).rejects.toThrow('agent exploded');
+    const errEvent = res.events.find((e) => e.event === 'error');
+    expect(errEvent).toBeDefined();
+    expect((errEvent!.data as any).message).toBe('agent exploded');
+    expect(res.writableEnded).toBe(true);
+  });
+
+  it('includes stepNumber as SSE id on step events', async () => {
+    const res = makeRes();
+    const emitter = new AgentSseEmitter(makeAgent(), res, { heartbeatIntervalMs: 0 });
+    await emitter.run('test');
+
+    const stepEvents = res.events.filter((e) => e.event === 'step');
+    expect(stepEvents[0].id).toBe('1');
+    expect(stepEvents[1].id).toBe('2');
+  });
+
+  it('sends heartbeat events on interval', async () => {
+    jest.useFakeTimers();
+
+    const res = makeRes();
+    const agent = makeAgent();
+
+    // The agent resolves after fake timers advance
+    let resolveRun!: (v: AgentRunResult) => void;
+    (agent.run as jest.Mock).mockReturnValue(
+      new Promise<AgentRunResult>((resolve) => { resolveRun = resolve; }),
+    );
+
+    const emitter = new AgentSseEmitter(agent, res, { heartbeatIntervalMs: 10 });
+    const emitPromise = emitter.run('test');
+
+    // Advance fake timers to trigger ≥3 heartbeats, then resolve the agent
+    jest.advanceTimersByTime(35);
+    resolveRun({
+      runId: 'r', answer: 'ok', steps: [], status: 'completed',
+    } as AgentRunResult);
+
+    await emitPromise;
+    jest.useRealTimers();
+
+    const heartbeats = res.events.filter((e) => e.event === 'heartbeat');
+    expect(heartbeats.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── createAgentSseHandler ────────────────────────────────────────────────────
+
+describe('createAgentSseHandler', () => {
+  it('reads input from query string', async () => {
+    const agent = makeAgent();
+    const handler = createAgentSseHandler(agent, { heartbeatIntervalMs: 0 });
+    const res = makeRes();
+    await handler({ query: { input: 'hello from query' } }, res);
+
+    expect(agent.run).toHaveBeenCalledWith('hello from query', expect.any(Object));
+  });
+
+  it('reads input from body.input', async () => {
+    const agent = makeAgent();
+    const handler = createAgentSseHandler(agent, { heartbeatIntervalMs: 0 });
+    const res = makeRes();
+    await handler({ body: { input: 'hello from body' } }, res);
+
+    expect(agent.run).toHaveBeenCalledWith('hello from body', expect.any(Object));
+  });
+
+  it('reads input from body.message', async () => {
+    const agent = makeAgent();
+    const handler = createAgentSseHandler(agent, { heartbeatIntervalMs: 0 });
+    const res = makeRes();
+    await handler({ body: { message: 'hello from message' } }, res);
+
+    expect(agent.run).toHaveBeenCalledWith('hello from message', expect.any(Object));
+  });
+
+  it('calls onMissingInput when no input is found', async () => {
+    const onMissingInput = jest.fn();
+    const agent = makeAgent();
+    const handler = createAgentSseHandler(agent, { heartbeatIntervalMs: 0, onMissingInput });
+    const res = makeRes();
+    await handler({}, res);
+
+    expect(onMissingInput).toHaveBeenCalledWith({}, res);
+    expect(agent.run).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 JSON by default when input missing (res.status/json available)', async () => {
+    const agent = makeAgent();
+    const handler = createAgentSseHandler(agent, { heartbeatIntervalMs: 0 });
+
+    const chunks: string[] = [];
+    const res = {
+      headersSent: false,
+      writableEnded: false,
+      headers: {} as Record<string, string>,
+      setHeader(k: string, v: string) { this.headers[k] = v; },
+      write(c: string) { chunks.push(c); return true; },
+      end() { this.writableEnded = true; },
+      status(code: number) { (this as any)._status = code; return this; },
+      json(body: unknown) { chunks.push(JSON.stringify(body)); return this; },
+    };
+
+    await handler({}, res);
+    expect(chunks.join('')).toContain('Missing input');
+    expect(agent.run).not.toHaveBeenCalled();
+  });
+
+  it('supports custom getInput extractor', async () => {
+    const agent = makeAgent();
+    const handler = createAgentSseHandler(agent, {
+      heartbeatIntervalMs: 0,
+      getInput: (req) => (req.body as any)?.question,
+    });
+    const res = makeRes();
+    await handler({ body: { question: 'custom question' } }, res);
+
+    expect(agent.run).toHaveBeenCalledWith('custom question', expect.any(Object));
+  });
+
+  it('emits full SSE event sequence for a complete run', async () => {
+    const agent = makeAgent();
+    const handler = createAgentSseHandler(agent, { heartbeatIntervalMs: 0 });
+    const res = makeRes();
+    await handler({ query: { input: 'test' } }, res);
+
+    const events = res.events.map((e) => e.event);
+    expect(events).toContain('step');
+    expect(events).toContain('done');
+    expect(events[events.length - 1]).toBe('done');
+    expect(res.writableEnded).toBe(true);
+  });
+});

--- a/tsfox/core/agents/index.ts
+++ b/tsfox/core/agents/index.ts
@@ -69,3 +69,20 @@ export type {
   CachedAgentOptions,
   AgentMetricSnapshot,
 } from './integrations';
+
+// Tools
+export {
+  HttpTool,
+  FilesystemTool,
+  createFilesystemTool,
+  CalculatorTool,
+  JsonPathTool,
+  createSqlQueryTool,
+  createVectorSearchTool,
+} from './tools';
+export type {
+  IQueryExecutor,
+  IVectorSearchProvider,
+  VectorSearchOptions,
+  VectorSearchResult,
+} from './tools';

--- a/tsfox/core/agents/index.ts
+++ b/tsfox/core/agents/index.ts
@@ -86,3 +86,15 @@ export type {
   VectorSearchOptions,
   VectorSearchResult,
 } from './tools';
+
+// Streaming UI
+export { SseStream, AgentSseEmitter, createAgentSseHandler } from './streaming';
+export type {
+  SseEvent,
+  ISseStream,
+  ServerResponseLike,
+  AgentSseEmitterOptions,
+  AgentSseHandlerOptions,
+  RequestLike,
+  ResponseLike,
+} from './streaming';

--- a/tsfox/core/agents/streaming/agent-sse-emitter.ts
+++ b/tsfox/core/agents/streaming/agent-sse-emitter.ts
@@ -1,0 +1,102 @@
+/**
+ * @fileoverview AgentSseEmitter — converts AgentStep / AgentRunResult events into SSE.
+ *
+ * SSE event types emitted:
+ *  - `step`        — one AgentStep (thought, tool_call, tool_result, final_answer)
+ *  - `done`        — AgentRunResult summary (answer + usage + status)
+ *  - `error`       — { message: string } when the run throws
+ *  - `heartbeat`   — `{}` sent on a configurable interval to keep the connection alive
+ */
+
+import type { AgentRunResult, AgentStep, IAgent } from '../interfaces/agent.interface';
+import { SseStream, type ServerResponseLike } from './sse-stream';
+
+export interface AgentSseEmitterOptions {
+  /** Heartbeat interval in ms. Set to 0 to disable (default: 15000) */
+  heartbeatIntervalMs?: number;
+}
+
+/**
+ * AgentSseEmitter — runs an `IAgent` and streams each step to the client over SSE.
+ *
+ * @example
+ * ```ts
+ * app.get('/agent/run', async (req, res) => {
+ *   const emitter = new AgentSseEmitter(myAgent, res);
+ *   await emitter.run(req.query.input as string);
+ * });
+ * ```
+ */
+export class AgentSseEmitter {
+  private readonly sse: SseStream;
+  private readonly opts: Required<AgentSseEmitterOptions>;
+
+  constructor(
+    private readonly agent: IAgent,
+    res: ServerResponseLike,
+    opts: AgentSseEmitterOptions = {},
+  ) {
+    this.sse = new SseStream(res);
+    this.opts = {
+      heartbeatIntervalMs: opts.heartbeatIntervalMs ?? 15_000,
+    };
+  }
+
+  async run(input: string): Promise<AgentRunResult> {
+    let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+
+    if (this.opts.heartbeatIntervalMs > 0) {
+      heartbeatTimer = setInterval(() => {
+        if (!this.sse.closed) this.sse.send({ event: 'heartbeat', data: {} });
+      }, this.opts.heartbeatIntervalMs);
+    }
+
+    try {
+      const result = await this.agent.run(input, {
+        runId: `sse-${Date.now()}`,
+        variables: {},
+      });
+
+      // Emit each step individually
+      for (const step of result.steps) {
+        this.emitStep(step);
+      }
+
+      // Emit final done event
+      this.sse.send({
+        event: 'done',
+        data: {
+          runId: result.runId,
+          answer: result.answer,
+          status: result.status,
+          usage: result.usage,
+          stepCount: result.steps.length,
+        },
+      });
+
+      return result;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.sse.send({ event: 'error', data: { message } });
+      throw err;
+    } finally {
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
+      this.sse.close();
+    }
+  }
+
+  private emitStep(step: AgentStep): void {
+    this.sse.send({
+      event: 'step',
+      id: step.stepNumber,
+      data: {
+        stepNumber: step.stepNumber,
+        type: step.type,
+        content: step.content,
+        toolCall: step.toolCall,
+        toolResult: step.toolResult,
+        timestamp: step.timestamp.toISOString(),
+      },
+    });
+  }
+}

--- a/tsfox/core/agents/streaming/create-agent-sse-handler.ts
+++ b/tsfox/core/agents/streaming/create-agent-sse-handler.ts
@@ -1,0 +1,100 @@
+/**
+ * @fileoverview createAgentSseHandler — Express/Fox route factory for streaming agents.
+ *
+ * Returns a request handler that:
+ *  1. Reads the `input` from the request (query param or JSON body)
+ *  2. Runs the agent via AgentSseEmitter
+ *  3. Streams SSE steps to the client
+ *  4. Ends with a `done` or `error` event
+ */
+
+import type { IAgent } from '../interfaces/agent.interface';
+import { AgentSseEmitter, type AgentSseEmitterOptions } from './agent-sse-emitter';
+import type { ServerResponseLike } from './sse-stream';
+
+/** Minimal Express-compatible Request */
+export interface RequestLike {
+  query?: Record<string, unknown>;
+  body?: unknown;
+}
+
+/** Minimal Express-compatible Response (ServerResponseLike + status/json for errors) */
+export interface ResponseLike extends ServerResponseLike {
+  status?(code: number): this;
+  json?(body: unknown): this;
+}
+
+export interface AgentSseHandlerOptions extends AgentSseEmitterOptions {
+  /**
+   * How to extract the user input from the request.
+   * Default: first checks `req.query.input`, then `req.body.input`, then `req.body.message`.
+   */
+  getInput?: (req: RequestLike) => string | undefined;
+  /**
+   * Called when input is missing (default: sends 400 JSON error if possible, else closes SSE).
+   */
+  onMissingInput?: (req: RequestLike, res: ResponseLike) => void;
+}
+
+/**
+ * createAgentSseHandler — factory that returns an Express/Fox request handler.
+ *
+ * @example
+ * ```ts
+ * // Express
+ * app.get('/stream', createAgentSseHandler(myAgent));
+ *
+ * // With options
+ * app.post('/stream', createAgentSseHandler(myAgent, {
+ *   getInput: (req) => (req.body as any).question,
+ *   heartbeatIntervalMs: 10_000,
+ * }));
+ * ```
+ */
+export function createAgentSseHandler(
+  agent: IAgent,
+  options: AgentSseHandlerOptions = {},
+): (req: RequestLike, res: ResponseLike) => Promise<void> {
+  const getInput =
+    options.getInput ??
+    ((req: RequestLike): string | undefined => {
+      if (req.query?.input) return String(req.query.input);
+      const body = req.body as Record<string, unknown> | undefined;
+      if (body?.input) return String(body.input);
+      if (body?.message) return String(body.message);
+      return undefined;
+    });
+
+  const onMissingInput =
+    options.onMissingInput ??
+    ((req: RequestLike, res: ResponseLike): void => {
+      if (!res.headersSent) {
+        if (res.status && res.json) {
+          res.status(400);
+          res.json({ error: 'Missing input parameter' });
+        } else {
+          res.setHeader('Content-Type', 'application/json');
+          res.write(JSON.stringify({ error: 'Missing input parameter' }));
+          res.end();
+        }
+      }
+    });
+
+  return async (req: RequestLike, res: ResponseLike): Promise<void> => {
+    const input = getInput(req);
+    if (!input) {
+      onMissingInput(req, res);
+      return;
+    }
+
+    const emitter = new AgentSseEmitter(agent, res, {
+      heartbeatIntervalMs: options.heartbeatIntervalMs,
+    });
+
+    try {
+      await emitter.run(input);
+    } catch {
+      // Error already sent as SSE `error` event; nothing more to do here.
+    }
+  };
+}

--- a/tsfox/core/agents/streaming/index.ts
+++ b/tsfox/core/agents/streaming/index.ts
@@ -1,0 +1,8 @@
+export { SseStream } from './sse-stream';
+export type { SseEvent, ISseStream, ServerResponseLike } from './sse-stream';
+
+export { AgentSseEmitter } from './agent-sse-emitter';
+export type { AgentSseEmitterOptions } from './agent-sse-emitter';
+
+export { createAgentSseHandler } from './create-agent-sse-handler';
+export type { AgentSseHandlerOptions, RequestLike, ResponseLike } from './create-agent-sse-handler';

--- a/tsfox/core/agents/streaming/sse-stream.ts
+++ b/tsfox/core/agents/streaming/sse-stream.ts
@@ -1,0 +1,88 @@
+/**
+ * @fileoverview Low-level SSE stream writer.
+ * Works with any Node.js `ServerResponse`-compatible object.
+ */
+
+export interface SseEvent {
+  /** SSE event type (maps to `event:` field) */
+  event: string;
+  /** Data payload — will be JSON-serialised */
+  data: unknown;
+  /** Optional SSE id */
+  id?: string | number;
+}
+
+export interface ISseStream {
+  send(event: SseEvent): void;
+  close(): void;
+  readonly closed: boolean;
+}
+
+/** Minimal interface for a Node.js / Express ServerResponse */
+export interface ServerResponseLike {
+  headersSent: boolean;
+  writableEnded: boolean;
+  writeHead?(statusCode: number, headers: Record<string, string>): void;
+  setHeader(name: string, value: string): void;
+  write(chunk: string): boolean;
+  end(): void;
+}
+
+/**
+ * SseStream — wraps a `ServerResponseLike` and provides a typed `send()` API.
+ *
+ * @example
+ * ```ts
+ * const sse = new SseStream(res);
+ * sse.send({ event: 'step', data: { content: 'Thinking...' } });
+ * sse.close();
+ * ```
+ */
+export class SseStream implements ISseStream {
+  private _closed = false;
+
+  constructor(private readonly res: ServerResponseLike) {
+    if (!res.headersSent) {
+      if (res.writeHead) {
+        res.writeHead(200, {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          Connection: 'keep-alive',
+          'X-Accel-Buffering': 'no',
+        });
+      } else {
+        res.setHeader('Content-Type', 'text/event-stream');
+        res.setHeader('Cache-Control', 'no-cache');
+        res.setHeader('Connection', 'keep-alive');
+        res.setHeader('X-Accel-Buffering', 'no');
+      }
+    }
+  }
+
+  get closed(): boolean {
+    return this._closed || this.res.writableEnded;
+  }
+
+  send(event: SseEvent): void {
+    if (this.closed) return;
+
+    let payload = '';
+    if (event.id !== undefined) payload += `id: ${event.id}\n`;
+    payload += `event: ${event.event}\n`;
+
+    const json = JSON.stringify(event.data);
+    // Multi-line data: each line must start with "data: "
+    for (const line of json.split('\n')) {
+      payload += `data: ${line}\n`;
+    }
+    payload += '\n';
+
+    this.res.write(payload);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this._closed = true;
+    this.res.end();
+  }
+}

--- a/tsfox/core/agents/tools/calculator.tool.ts
+++ b/tsfox/core/agents/tools/calculator.tool.ts
@@ -1,0 +1,158 @@
+import { ITool, AgentContext } from '../interfaces/agent.interface';
+
+export const CalculatorTool: ITool = {
+  definition: {
+    name: 'calculator',
+    description:
+      'Evaluate mathematical expressions. Supports arithmetic (+, -, *, /, **, %), ' +
+      'parentheses, and math functions: sqrt, abs, ceil, floor, round, log, sin, cos, tan. ' +
+      'Constants: PI, E. Example: "sqrt(144) + 2 ** 8"',
+    parameters: {
+      type: 'object',
+      properties: {
+        expression: {
+          type: 'string',
+          description: 'Mathematical expression to evaluate',
+        },
+      },
+      required: ['expression'],
+    },
+  },
+
+  async execute(params: Record<string, unknown>, _ctx: AgentContext): Promise<string> {
+    const expression = (params.expression as string).trim();
+    try {
+      const result = evaluate(expression);
+      return `${expression} = ${result}`;
+    } catch (err: unknown) {
+      throw new Error(`CalculatorTool: ${(err as Error).message}`);
+    }
+  },
+};
+
+// ─── Safe expression parser ──────────────────────────────────────────────────
+
+const MATH_FUNS: Record<string, (x: number) => number> = {
+  sqrt: Math.sqrt, abs: Math.abs, ceil: Math.ceil, floor: Math.floor,
+  round: Math.round, log: Math.log, log2: Math.log2, log10: Math.log10,
+  sin: Math.sin, cos: Math.cos, tan: Math.tan,
+  asin: Math.asin, acos: Math.acos, atan: Math.atan,
+  exp: Math.exp, sign: Math.sign, trunc: Math.trunc,
+};
+
+const MATH_CONSTS: Record<string, number> = {
+  PI: Math.PI, E: Math.E, LN2: Math.LN2, LN10: Math.LN10, SQRT2: Math.SQRT2,
+};
+
+function evaluate(expr: string): number {
+  const tokens = tokenise(expr);
+  const ctx = { tokens, pos: 0 };
+  const result = parseExpr(ctx);
+  if (ctx.pos < ctx.tokens.length) {
+    throw new Error(`unexpected token "${ctx.tokens[ctx.pos].value}" at position ${ctx.pos}`);
+  }
+  return result;
+}
+
+type Token = { type: 'num' | 'op' | 'lparen' | 'rparen' | 'ident'; value: string };
+type Ctx = { tokens: Token[]; pos: number };
+
+function tokenise(expr: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  while (i < expr.length) {
+    const ch = expr[i];
+    if (/\s/.test(ch)) { i++; continue; }
+    if (/\d/.test(ch) || (ch === '.' && /\d/.test(expr[i + 1] ?? ''))) {
+      let num = '';
+      while (i < expr.length && /[\d.]/.test(expr[i])) num += expr[i++];
+      tokens.push({ type: 'num', value: num });
+    } else if (/[a-zA-Z_]/.test(ch)) {
+      let ident = '';
+      while (i < expr.length && /[a-zA-Z0-9_]/.test(expr[i])) ident += expr[i++];
+      tokens.push({ type: 'ident', value: ident });
+    } else if (ch === '(') {
+      tokens.push({ type: 'lparen', value: ch }); i++;
+    } else if (ch === ')') {
+      tokens.push({ type: 'rparen', value: ch }); i++;
+    } else if ('+-*/%^'.includes(ch)) {
+      if (ch === '*' && expr[i + 1] === '*') {
+        tokens.push({ type: 'op', value: '**' }); i += 2;
+      } else {
+        tokens.push({ type: 'op', value: ch }); i++;
+      }
+    } else {
+      throw new Error(`unexpected character "${ch}"`);
+    }
+  }
+  return tokens;
+}
+
+function peek(ctx: Ctx): Token | undefined { return ctx.tokens[ctx.pos]; }
+function consume(ctx: Ctx): Token { return ctx.tokens[ctx.pos++]; }
+
+function parseExpr(ctx: Ctx): number { return parseAddSub(ctx); }
+
+function parseAddSub(ctx: Ctx): number {
+  let left = parseMulDiv(ctx);
+  while (peek(ctx)?.type === 'op' && (peek(ctx)!.value === '+' || peek(ctx)!.value === '-')) {
+    const op = consume(ctx).value;
+    const right = parseMulDiv(ctx);
+    left = op === '+' ? left + right : left - right;
+  }
+  return left;
+}
+
+function parseMulDiv(ctx: Ctx): number {
+  let left = parsePow(ctx);
+  while (peek(ctx)?.type === 'op' && ['*', '/', '%'].includes(peek(ctx)!.value)) {
+    const op = consume(ctx).value;
+    const right = parsePow(ctx);
+    if (op === '*') left *= right;
+    else if (op === '/') { if (right === 0) throw new Error('division by zero'); left /= right; }
+    else left %= right;
+  }
+  return left;
+}
+
+function parsePow(ctx: Ctx): number {
+  const base = parseUnary(ctx);
+  if (peek(ctx)?.type === 'op' && peek(ctx)!.value === '**') {
+    consume(ctx);
+    return Math.pow(base, parsePow(ctx));
+  }
+  return base;
+}
+
+function parseUnary(ctx: Ctx): number {
+  if (peek(ctx)?.type === 'op' && peek(ctx)!.value === '-') { consume(ctx); return -parsePrimary(ctx); }
+  if (peek(ctx)?.type === 'op' && peek(ctx)!.value === '+') { consume(ctx); }
+  return parsePrimary(ctx);
+}
+
+function parsePrimary(ctx: Ctx): number {
+  const tok = peek(ctx);
+  if (!tok) throw new Error('unexpected end of expression');
+  if (tok.type === 'num') { consume(ctx); return parseFloat(tok.value); }
+  if (tok.type === 'lparen') {
+    consume(ctx);
+    const val = parseExpr(ctx);
+    if (peek(ctx)?.type !== 'rparen') throw new Error('missing closing parenthesis');
+    consume(ctx);
+    return val;
+  }
+  if (tok.type === 'ident') {
+    consume(ctx);
+    if (tok.value in MATH_CONSTS) return MATH_CONSTS[tok.value];
+    if (tok.value in MATH_FUNS) {
+      if (peek(ctx)?.type !== 'lparen') throw new Error(`expected "(" after "${tok.value}"`);
+      consume(ctx);
+      const arg = parseExpr(ctx);
+      if (peek(ctx)?.type !== 'rparen') throw new Error(`missing ")" after "${tok.value}(...)"`);
+      consume(ctx);
+      return MATH_FUNS[tok.value](arg);
+    }
+    throw new Error(`unknown identifier "${tok.value}"`);
+  }
+  throw new Error(`unexpected token "${tok.value}"`);
+}

--- a/tsfox/core/agents/tools/filesystem.tool.ts
+++ b/tsfox/core/agents/tools/filesystem.tool.ts
@@ -1,0 +1,105 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { ITool, AgentContext } from '../interfaces/agent.interface';
+
+export function createFilesystemTool(options: { allowedBase?: string } = {}): ITool {
+  const allowedBase = options.allowedBase ? path.resolve(options.allowedBase) : null;
+
+  function safeResolve(filePath: string): string {
+    const resolved = path.resolve(filePath);
+    if (allowedBase && !resolved.startsWith(allowedBase + path.sep) && resolved !== allowedBase) {
+      throw new Error(
+        `FilesystemTool: path "${filePath}" is outside allowed base "${allowedBase}"`,
+      );
+    }
+    return resolved;
+  }
+
+  return {
+    definition: {
+      name: 'filesystem',
+      description:
+        'Read, write, append, list, delete files and directories on the local filesystem.',
+      parameters: {
+        type: 'object',
+        properties: {
+          operation: {
+            type: 'string',
+            enum: ['read', 'write', 'append', 'list', 'exists', 'delete', 'mkdir'],
+            description: 'Filesystem operation to perform',
+          },
+          path: {
+            type: 'string',
+            description: 'File or directory path',
+          },
+          content: {
+            type: 'string',
+            description: 'Content to write or append',
+          },
+          encoding: {
+            type: 'string',
+            enum: ['utf8', 'base64', 'hex'],
+            description: 'File encoding (default: utf8)',
+          },
+        },
+        required: ['operation', 'path'],
+      },
+    },
+
+    async execute(params: Record<string, unknown>, _ctx: AgentContext): Promise<string> {
+      const operation = params.operation as string;
+      const filePath = safeResolve(params.path as string);
+      const encoding = (params.encoding as BufferEncoding) ?? 'utf8';
+
+      switch (operation) {
+        case 'read': {
+          if (!fs.existsSync(filePath)) throw new Error(`FilesystemTool: file not found: "${filePath}"`);
+          const content = fs.readFileSync(filePath, encoding);
+          const stats = fs.statSync(filePath);
+          return `File: ${filePath} (${stats.size} bytes)\n\n${content}`;
+        }
+        case 'write': {
+          const content = (params.content as string) ?? '';
+          const dir = path.dirname(filePath);
+          if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+          fs.writeFileSync(filePath, content, encoding);
+          return `Written ${content.length} characters to "${filePath}"`;
+        }
+        case 'append': {
+          const content = (params.content as string) ?? '';
+          fs.appendFileSync(filePath, content, encoding);
+          const stats = fs.statSync(filePath);
+          return `Appended ${content.length} characters to "${filePath}" (total: ${stats.size} bytes)`;
+        }
+        case 'list': {
+          if (!fs.existsSync(filePath)) throw new Error(`FilesystemTool: directory not found: "${filePath}"`);
+          const entries = fs.readdirSync(filePath, { withFileTypes: true });
+          const lines = entries.map((e) => {
+            const type = e.isDirectory() ? 'd' : 'f';
+            const size = type === 'f' ? fs.statSync(path.join(filePath, e.name)).size : '-';
+            return `[${type}] ${e.name}${type === 'f' ? ` (${size} bytes)` : '/'}`;
+          });
+          return `Contents of "${filePath}" (${lines.length} entries):\n${lines.join('\n')}`;
+        }
+        case 'exists': {
+          const exists = fs.existsSync(filePath);
+          const type = exists ? (fs.statSync(filePath).isDirectory() ? 'directory' : 'file') : 'not found';
+          return `"${filePath}": ${type}`;
+        }
+        case 'delete': {
+          if (!fs.existsSync(filePath)) return `"${filePath}" does not exist (nothing to delete)`;
+          fs.unlinkSync(filePath);
+          return `Deleted "${filePath}"`;
+        }
+        case 'mkdir': {
+          fs.mkdirSync(filePath, { recursive: true });
+          return `Directory created: "${filePath}"`;
+        }
+        default:
+          throw new Error(`FilesystemTool: unknown operation "${operation}"`);
+      }
+    },
+  };
+}
+
+export const FilesystemTool: ITool = createFilesystemTool();

--- a/tsfox/core/agents/tools/http.tool.ts
+++ b/tsfox/core/agents/tools/http.tool.ts
@@ -1,0 +1,100 @@
+import { ITool, AgentContext } from '../interfaces/agent.interface';
+
+/**
+ * HttpTool — makes HTTP requests (GET, POST, PUT, PATCH, DELETE)
+ */
+export const HttpTool: ITool = {
+  definition: {
+    name: 'http',
+    description:
+      'Make HTTP requests to external URLs. Supports GET, POST, PUT, PATCH, DELETE. ' +
+      'Returns the response body as text or JSON.',
+    parameters: {
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          description: 'The full URL to request (must start with http:// or https://)',
+        },
+        method: {
+          type: 'string',
+          enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
+          description: 'HTTP method (default: GET)',
+        },
+        headers: {
+          type: 'object',
+          description: 'Optional HTTP headers as key-value pairs',
+        },
+        body: {
+          type: 'string',
+          description: 'Optional request body. Objects are serialised to JSON automatically.',
+        },
+        timeout: {
+          type: 'number',
+          description: 'Request timeout in milliseconds (default: 10000)',
+        },
+      },
+      required: ['url'],
+    },
+  },
+
+  async execute(params: Record<string, unknown>, _context: AgentContext): Promise<string> {
+    const url = params.url as string;
+    const method = ((params.method as string) ?? 'GET').toUpperCase();
+    const headers = (params.headers as Record<string, string>) ?? {};
+    const timeoutMs = (params.timeout as number) ?? 10_000;
+
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      throw new Error(`HttpTool: invalid URL "${url}" — must start with http:// or https://`);
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    let bodyStr: string | undefined;
+    if (params.body !== undefined) {
+      if (typeof params.body === 'string') {
+        bodyStr = params.body;
+      } else {
+        bodyStr = JSON.stringify(params.body);
+        if (!headers['Content-Type'] && !headers['content-type']) {
+          headers['Content-Type'] = 'application/json';
+        }
+      }
+    }
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers,
+        body: bodyStr,
+        signal: controller.signal,
+      });
+
+      clearTimeout(timer);
+
+      const contentType = response.headers.get('content-type') ?? '';
+      const text = await response.text();
+
+      if (!response.ok) {
+        return `HTTP ${response.status} ${response.statusText}\n${text}`;
+      }
+
+      if (contentType.includes('application/json') || contentType.includes('text/json')) {
+        try {
+          return JSON.stringify(JSON.parse(text), null, 2);
+        } catch {
+          return text;
+        }
+      }
+
+      return text;
+    } catch (err: unknown) {
+      clearTimeout(timer);
+      if ((err as Error).name === 'AbortError') {
+        throw new Error(`HttpTool: request to "${url}" timed out after ${timeoutMs}ms`);
+      }
+      throw err;
+    }
+  },
+};

--- a/tsfox/core/agents/tools/index.ts
+++ b/tsfox/core/agents/tools/index.ts
@@ -1,0 +1,13 @@
+export { HttpTool } from './http.tool';
+export { FilesystemTool, createFilesystemTool } from './filesystem.tool';
+export { CalculatorTool } from './calculator.tool';
+export { JsonPathTool } from './jsonpath.tool';
+export { createSqlQueryTool } from './sql-query.tool';
+export { createVectorSearchTool } from './vector-search.tool';
+
+export type { IQueryExecutor } from './sql-query.tool';
+export type {
+  IVectorSearchProvider,
+  VectorSearchOptions,
+  VectorSearchResult,
+} from './vector-search.tool';

--- a/tsfox/core/agents/tools/jsonpath.tool.ts
+++ b/tsfox/core/agents/tools/jsonpath.tool.ts
@@ -1,0 +1,112 @@
+import { ITool, AgentContext } from '../interfaces/agent.interface';
+
+export const JsonPathTool: ITool = {
+  definition: {
+    name: 'jsonpath',
+    description:
+      'Extract and query data from JSON. Navigate objects and arrays using dot/bracket paths. ' +
+      'Operations: get, keys, count, flatten, pretty. ' +
+      'Example: path=".users[0].name", operation="get"',
+    parameters: {
+      type: 'object',
+      properties: {
+        json: {
+          type: 'string',
+          description: 'JSON string to query',
+        },
+        path: {
+          type: 'string',
+          description: 'Path expression: "." for root, ".field", "[0]", ".*", "[*]"',
+        },
+        operation: {
+          type: 'string',
+          enum: ['get', 'keys', 'count', 'flatten', 'pretty'],
+          description: 'Operation to perform (default: get)',
+        },
+      },
+      required: ['json', 'path'],
+    },
+  },
+
+  async execute(params: Record<string, unknown>, _ctx: AgentContext): Promise<string> {
+    const operation = (params.operation as string) ?? 'get';
+    let data: unknown;
+
+    if (typeof params.json === 'string') {
+      try { data = JSON.parse(params.json as string); }
+      catch { throw new Error('JsonPathTool: invalid JSON input'); }
+    } else {
+      data = params.json;
+    }
+
+    const pathStr = (params.path as string).trim();
+    const value = resolvePath(data, pathStr);
+
+    switch (operation) {
+      case 'get': return JSON.stringify(value, null, 2);
+      case 'keys': {
+        if (typeof value !== 'object' || value === null)
+          throw new Error(`JsonPathTool: cannot get keys of non-object at "${pathStr}"`);
+        const keys = Array.isArray(value)
+          ? value.map((_, i) => String(i))
+          : Object.keys(value as object);
+        return keys.join(', ');
+      }
+      case 'count': {
+        if (Array.isArray(value)) return String(value.length);
+        if (typeof value === 'object' && value !== null) return String(Object.keys(value as object).length);
+        if (typeof value === 'string') return String(value.length);
+        throw new Error(`JsonPathTool: cannot count "${typeof value}"`);
+      }
+      case 'flatten': {
+        if (!Array.isArray(value)) throw new Error('JsonPathTool: flatten requires an array');
+        return JSON.stringify(flatDeep(value), null, 2);
+      }
+      case 'pretty': return JSON.stringify(value, null, 2);
+      default: throw new Error(`JsonPathTool: unknown operation "${operation}"`);
+    }
+  },
+};
+
+function resolvePath(data: unknown, pathStr: string): unknown {
+  if (pathStr === '.' || pathStr === '') return data;
+  const tokens: Array<{ type: 'key' | 'index' | 'wildcard_obj' | 'wildcard_arr'; value: string }> = [];
+  const re = /\.(\*)|\.([a-zA-Z_$][a-zA-Z0-9_$]*|\d+)|\[(\*|\d+)\]/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(pathStr)) !== null) {
+    if (match[1] !== undefined) tokens.push({ type: 'wildcard_obj', value: '*' });
+    else if (match[2] !== undefined) tokens.push({ type: 'key', value: match[2] });
+    else if (match[3] === '*') tokens.push({ type: 'wildcard_arr', value: '*' });
+    else tokens.push({ type: 'index', value: match[3] });
+  }
+  if (tokens.length === 0) throw new Error(`JsonPathTool: invalid path "${pathStr}"`);
+
+  let current: unknown = data;
+  for (const token of tokens) {
+    if (current === null || current === undefined)
+      throw new Error(`JsonPathTool: null/undefined at path "${pathStr}"`);
+    if (token.type === 'key') {
+      if (typeof current !== 'object' || Array.isArray(current))
+        throw new Error(`JsonPathTool: expected object for ".${token.value}"`);
+      current = (current as Record<string, unknown>)[token.value];
+    } else if (token.type === 'index') {
+      if (!Array.isArray(current)) throw new Error(`JsonPathTool: expected array for "[${token.value}]"`);
+      const idx = parseInt(token.value, 10);
+      current = (current as unknown[])[idx < 0 ? current.length + idx : idx];
+    } else if (token.type === 'wildcard_obj') {
+      if (typeof current !== 'object' || Array.isArray(current))
+        throw new Error('JsonPathTool: ".*" requires an object');
+      current = Object.values(current as object);
+    }
+    // wildcard_arr: return as-is
+  }
+  return current;
+}
+
+function flatDeep(arr: unknown[]): unknown[] {
+  return arr.reduce<unknown[]>((acc, val) => {
+    if (Array.isArray(val)) acc.push(...flatDeep(val));
+    else acc.push(val);
+    return acc;
+  }, []);
+}

--- a/tsfox/core/agents/tools/sql-query.tool.ts
+++ b/tsfox/core/agents/tools/sql-query.tool.ts
@@ -1,0 +1,71 @@
+import { ITool, AgentContext } from '../interfaces/agent.interface';
+
+export interface IQueryExecutor {
+  query(sql: string, params?: unknown[]): Promise<{ rows: unknown[]; rowCount: number }>;
+}
+
+export function createSqlQueryTool(
+  executor: IQueryExecutor,
+  options: { allowMutations?: boolean; maxRows?: number; label?: string } = {},
+): ITool {
+  const allowMutations = options.allowMutations ?? false;
+  const maxRows = options.maxRows ?? 100;
+  const toolName = options.label ?? 'sql_query';
+
+  return {
+    definition: {
+      name: toolName,
+      description:
+        'Execute SQL queries against the connected database. ' +
+        (allowMutations
+          ? 'Supports SELECT, INSERT, UPDATE, DELETE.'
+          : 'Read-only: only SELECT statements are permitted.') +
+        ` Results are capped at ${maxRows} rows.`,
+      parameters: {
+        type: 'object',
+        properties: {
+          sql: { type: 'string', description: 'SQL statement to execute' },
+          params: {
+            type: 'array',
+            description: 'Optional parameterised values',
+            items: { type: 'string' },
+          },
+        },
+        required: ['sql'],
+      },
+    },
+
+    async execute(p: Record<string, unknown>, _ctx: AgentContext): Promise<string> {
+      const sql = (p.sql as string).trim();
+      const params = (p.params as unknown[]) ?? [];
+
+      if (!allowMutations) {
+        const upper = sql.toUpperCase().replace(/\s+/g, ' ');
+        if (/^(INSERT|UPDATE|DELETE|DROP|TRUNCATE|ALTER|CREATE|REPLACE)/.test(upper)) {
+          throw new Error(`SqlQueryTool: mutation statements are not allowed.`);
+        }
+      }
+
+      const result = await executor.query(sql, params);
+      const rows = result.rows.slice(0, maxRows);
+
+      if (rows.length === 0) return `Query executed. 0 rows returned. (rowCount: ${result.rowCount})`;
+
+      const headers = Object.keys(rows[0] as object);
+      const sep = headers.map(() => '---');
+      const body = rows.map((row) => {
+        const vals = headers.map((h) => {
+          const v = (row as Record<string, unknown>)[h];
+          return v === null || v === undefined ? 'NULL' : String(v);
+        });
+        return `| ${vals.join(' | ')} |`;
+      }).join('\n');
+
+      const truncNote = result.rows.length > maxRows
+        ? `\n\n*Results truncated to ${maxRows} rows (total: ${result.rows.length})*`
+        : '';
+
+      return `| ${headers.join(' | ')} |\n| ${sep.join(' | ')} |\n${body}${truncNote}`;
+    },
+  };
+}

--- a/tsfox/core/agents/tools/vector-search.tool.ts
+++ b/tsfox/core/agents/tools/vector-search.tool.ts
@@ -1,0 +1,72 @@
+import { ITool, AgentContext } from '../interfaces/agent.interface';
+
+export interface IVectorSearchProvider {
+  search(query: string, options?: VectorSearchOptions): Promise<VectorSearchResult[]>;
+  upsert?(id: string, text: string, metadata?: Record<string, unknown>): Promise<void>;
+  delete?(id: string): Promise<void>;
+}
+
+export interface VectorSearchOptions {
+  topK?: number;
+  minScore?: number;
+  filter?: Record<string, unknown>;
+  namespace?: string;
+}
+
+export interface VectorSearchResult {
+  id: string;
+  score: number;
+  text: string;
+  metadata?: Record<string, unknown>;
+}
+
+export function createVectorSearchTool(
+  provider: IVectorSearchProvider,
+  options: { label?: string; description?: string; defaultTopK?: number; defaultMinScore?: number } = {},
+): ITool {
+  const toolName = options.label ?? 'vector_search';
+  const defaultTopK = options.defaultTopK ?? 5;
+  const defaultMinScore = options.defaultMinScore ?? 0.0;
+
+  return {
+    definition: {
+      name: toolName,
+      description:
+        options.description ??
+        'Perform semantic similarity search over a vector store. ' +
+          'Returns the most relevant documents based on meaning, not just keywords.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Natural language query for semantic search' },
+          top_k: { type: 'number', description: `Number of results to return (default: ${defaultTopK})` },
+          min_score: { type: 'number', description: `Minimum similarity score 0.0–1.0 (default: ${defaultMinScore})` },
+          filter: { type: 'object', description: 'Optional metadata filter' },
+          namespace: { type: 'string', description: 'Optional namespace/collection to search in' },
+        },
+        required: ['query'],
+      },
+    },
+
+    async execute(params: Record<string, unknown>, _ctx: AgentContext): Promise<string> {
+      const query = params.query as string;
+      const topK = (params.top_k as number) ?? defaultTopK;
+      const minScore = (params.min_score as number) ?? defaultMinScore;
+      const filter = params.filter as Record<string, unknown> | undefined;
+      const namespace = params.namespace as string | undefined;
+
+      const results = await provider.search(query, { topK, minScore, filter, namespace });
+
+      if (results.length === 0) return `No results found for query: "${query}"`;
+
+      const lines = results.map((r, i) => {
+        const meta = r.metadata && Object.keys(r.metadata).length > 0
+          ? ` [${Object.entries(r.metadata).map(([k, v]) => `${k}=${v}`).join(', ')}]`
+          : '';
+        return `${i + 1}. (score: ${r.score.toFixed(4)})${meta}\n   ${r.text}`;
+      });
+
+      return `Vector search results for "${query}" (${results.length} found):\n\n${lines.join('\n\n')}`;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add server-sent event (SSE) streaming infrastructure for agent runs in `tsfox/core/agents/streaming/`
- Agents can now stream reasoning steps to the browser in real time with a single route factory call
- 21 tests passing

## API

### `SseStream`
Low-level SSE writer compatible with Express, Fox, and raw Node.js `ServerResponse`.

```ts
const sse = new SseStream(res);
sse.send({ event: 'step', data: { content: 'Thinking...' }, id: 1 });
sse.close();
```

### `AgentSseEmitter`
Runs an `IAgent` and emits SSE events for each step:

| Event | When |
|-------|------|
| `step` | Each `AgentStep` (thought, tool_call, tool_result, final_answer) |
| `done` | Run complete (answer, usage, stepCount) |
| `error` | Agent threw |
| `heartbeat` | Configurable keep-alive ping |

```ts
const emitter = new AgentSseEmitter(agent, res, { heartbeatIntervalMs: 15_000 });
await emitter.run('What is the capital of France?');
```

### `createAgentSseHandler`
Express/Fox route factory — one line to add streaming to a route:

```ts
app.get('/agent/stream', createAgentSseHandler(myAgent));
// POST with body: { input: '...' } or { message: '...' }
app.post('/agent/stream', createAgentSseHandler(myAgent, {
  getInput: (req) => req.body.question,
  heartbeatIntervalMs: 10_000,
}));
```

## Files Changed
- `tsfox/core/agents/streaming/sse-stream.ts` *(new)*
- `tsfox/core/agents/streaming/agent-sse-emitter.ts` *(new)*
- `tsfox/core/agents/streaming/create-agent-sse-handler.ts` *(new)*
- `tsfox/core/agents/streaming/index.ts` *(new — barrel)*
- `tsfox/core/agents/index.ts` *(updated — re-exports streaming)*
- `tsfox/core/agents/__tests__/epic-d3.test.ts` *(new — 21 tests)*