### PR TITLE
docs(v1.4.2): agent tools, SSE streaming, telemetry, vector stores

### DIFF
--- a/website/pages/docs/_meta.json
+++ b/website/pages/docs/_meta.json
@@ -26,7 +26,7 @@
   "cli": "Herramientas CLI",
   "plugins": "Sistema de Plugins",
   "ai-agents": {
-    "title": "AI & Agents (v1.3)",
+    "title": "AI & Agents (v1.4)",
     "type": "separator"
   },
   "agents": "Sistema de Agentes",

--- a/website/pages/docs/agents.mdx
+++ b/website/pages/docs/agents.mdx
@@ -214,9 +214,276 @@ interface IModelProvider {
 
 ```typescript
 interface ITool {
-  name: string;
-  description: string;
-  parameters: JSONSchema;
-  execute(params: Record<string, unknown>): Promise<string>;
+  definition: {
+    name: string;
+    description: string;
+    parameters: JSONSchema;
+  };
+  execute(params: Record<string, unknown>, context: AgentContext): Promise<string>;
 }
+```
+
+---
+
+## Built-in Tools (v1.4)
+
+Fox Framework ships six ready-to-use tools in `@foxframework/core/agents/tools`. Import them individually:
+
+```typescript
+import {
+  CalculatorTool,
+  HttpTool,
+  FilesystemTool,
+  createFilesystemTool,
+  JsonPathTool,
+  createSqlQueryTool,
+  createVectorSearchTool,
+} from '@foxframework/core/agents/tools';
+```
+
+### CalculatorTool
+
+Evaluates mathematical expressions safely (no `eval`). Supports arithmetic, `**`, `%`, and functions: `sqrt`, `abs`, `ceil`, `floor`, `round`, `log`, `sin`, `cos`, `tan`. Constants: `PI`, `E`.
+
+```typescript
+const agent = new ReActAgent({
+  model,
+  tools: [CalculatorTool],
+});
+// Agent input: "What is sqrt(144) + 2**8?"
+// Tool call: { expression: "sqrt(144) + 2**8" }
+// Result: "sqrt(144) + 2**8 = 268"
+```
+
+### HttpTool
+
+Makes HTTP requests (GET, POST, PUT, PATCH, DELETE) using native `fetch`. Returns formatted JSON or plain text.
+
+```typescript
+const agent = new ReActAgent({
+  model,
+  tools: [HttpTool],
+});
+// Agent input: "Get the latest rates from https://api.exchangerate.host/latest"
+```
+
+### FilesystemTool
+
+Reads, writes, appends, lists, and deletes files/directories. Use `createFilesystemTool` to restrict access to a safe directory:
+
+```typescript
+// Unrestricted (default)
+import { FilesystemTool } from '@foxframework/core/agents/tools';
+
+// Restricted to a specific directory
+const safeTool = createFilesystemTool({ allowedBase: '/tmp/agent-workspace' });
+
+const agent = new ReActAgent({ model, tools: [safeTool] });
+```
+
+Operations: `read`, `write`, `append`, `list`, `exists`, `delete`, `mkdir`.
+
+### JsonPathTool
+
+Queries and extracts data from JSON using path expressions:
+
+```typescript
+const agent = new ReActAgent({ model, tools: [JsonPathTool] });
+// Tool call: { json: '{"users":[{"name":"Alice"}]}', path: ".users[0].name", operation: "get" }
+// Result: '"Alice"'
+```
+
+Operations: `get`, `keys`, `count`, `flatten`, `pretty`.
+
+### SqlQueryTool (factory)
+
+Wraps any `IQueryExecutor` to let the agent run SQL. Read-only by default; set `allowMutations: true` to allow writes:
+
+```typescript
+import { createSqlQueryTool } from '@foxframework/core/agents/tools';
+import { PostgresProvider } from '@foxframework/db-postgres';
+
+const db = new PostgresProvider({ connectionString: process.env.DATABASE_URL });
+
+const sqlTool = createSqlQueryTool(db, {
+  allowMutations: false, // only SELECT (default)
+  maxRows: 50,           // cap results (default: 100)
+  label: 'database',    // tool name shown to the model
+});
+
+const agent = new ReActAgent({ model, tools: [sqlTool] });
+```
+
+### VectorSearchTool (factory)
+
+Wraps any `IVectorSearchProvider` (Pinecone, Weaviate, Chroma, or custom) for semantic retrieval:
+
+```typescript
+import { createVectorSearchTool } from '@foxframework/core/agents/tools';
+import { PineconeProvider } from '@foxframework/vector-pinecone';
+
+const vectorProvider = new PineconeProvider({
+  apiKey: process.env.PINECONE_API_KEY!,
+  indexHost: process.env.PINECONE_INDEX_HOST!,
+  embed: async (text) => myEmbeddingFn(text),
+});
+
+const vectorTool = createVectorSearchTool(vectorProvider, {
+  label: 'knowledge_search',
+  defaultTopK: 5,
+});
+
+const agent = new ReActAgent({ model, tools: [vectorTool] });
+```
+
+---
+
+## Streaming (v1.4)
+
+Stream agent steps to the browser over **Server-Sent Events (SSE)**. Three layers of abstraction:
+
+### SseStream — low-level
+
+Wraps any `ServerResponse`-compatible object and writes formatted SSE frames:
+
+```typescript
+import { SseStream } from '@foxframework/core/agents/streaming';
+
+app.get('/sse', (req, res) => {
+  const sse = new SseStream(res); // sets SSE headers automatically
+  sse.send({ event: 'message', data: { text: 'Hello!' } });
+  sse.close();
+});
+```
+
+### AgentSseEmitter — mid-level
+
+Runs an agent and streams every step as SSE events:
+
+```typescript
+import { AgentSseEmitter } from '@foxframework/core/agents/streaming';
+
+app.get('/agent/stream', async (req, res) => {
+  const emitter = new AgentSseEmitter(myAgent, res, {
+    heartbeatIntervalMs: 15_000, // keeps proxy connections alive (default: 15s)
+  });
+  await emitter.run(req.query.input as string);
+});
+```
+
+SSE events emitted:
+
+| Event | Payload | When |
+|---|---|---|
+| `step` | `{ stepNumber, type, content, toolCall?, toolResult? }` | After each agent step |
+| `done` | `{ runId, answer, status, usage, stepCount }` | Run completed |
+| `error` | `{ message }` | Run threw an exception |
+| `heartbeat` | `{}` | Every `heartbeatIntervalMs` |
+
+### createAgentSseHandler — route factory
+
+Creates a ready-to-use Express/Fox request handler:
+
+```typescript
+import { createAgentSseHandler } from '@foxframework/core/agents/streaming';
+
+// Default: reads input from req.query.input, req.body.input, or req.body.message
+app.get('/stream', createAgentSseHandler(myAgent));
+
+// Custom input extraction
+app.post('/stream', createAgentSseHandler(myAgent, {
+  getInput: (req) => (req.body as any).question,
+  heartbeatIntervalMs: 10_000,
+}));
+```
+
+### Client-side consumption
+
+```typescript
+const es = new EventSource('/stream?input=What+is+the+capital+of+France%3F');
+
+es.addEventListener('step', (e) => {
+  const step = JSON.parse(e.data);
+  console.log(`[${step.type}] ${step.content}`);
+});
+
+es.addEventListener('done', (e) => {
+  const result = JSON.parse(e.data);
+  console.log('Answer:', result.answer);
+  es.close();
+});
+
+es.addEventListener('error', (e) => {
+  console.error('Agent error:', JSON.parse(e.data).message);
+  es.close();
+});
+```
+
+---
+
+## Telemetry / Tracing (v1.4)
+
+### AgentTracer
+
+`AgentTracer` is a proxy that wraps any `IAgent` and emits spans for every run and tool call. It is vendor-neutral — plug in any `ITracer` backend.
+
+```typescript
+import { AgentTracer } from '@foxframework/core/agents/telemetry';
+
+// With a no-op tracer (default — zero overhead)
+const tracedAgent = new AgentTracer(myAgent);
+
+// With a custom tracer
+const tracedAgent = new AgentTracer(myAgent, { tracer: myTracer });
+```
+
+Spans emitted:
+
+| Span | Attributes |
+|---|---|
+| `agent.run` | `agent.id`, `agent.name`, `agent.input`, `run.id`, `run.status`, `run.stepCount`, `run.answer`, `llm.*_tokens` |
+| `agent.tool_call` | `tool.name`, `tool.call_id`, `tool.arguments`, `agent.id`, `step.number` |
+
+### ITracer interface
+
+Implement `ITracer` for any tracing backend:
+
+```typescript
+import type { ITracer, ISpan } from '@foxframework/core/agents/telemetry';
+
+class ConsoleTracer implements ITracer {
+  startSpan(name: string): ISpan {
+    const start = Date.now();
+    console.log(`[span start] ${name}`);
+    return {
+      setAttribute: (k, v) => { console.log(`  ${k}=${v}`); return this as any; },
+      recordException: (e) => { console.error('  exception:', e); return this as any; },
+      setStatus: (s, m) => { console.log(`  status=${s}`, m ?? ''); return this as any; },
+      end: () => console.log(`[span end] ${name} (${Date.now() - start}ms)`),
+    };
+  }
+}
+
+const tracedAgent = new AgentTracer(myAgent, { tracer: new ConsoleTracer() });
+```
+
+### OpenTelemetry via @foxframework/otel-agents
+
+For production OTel tracing, install the adapter package:
+
+```bash
+npm install @foxframework/otel-agents @opentelemetry/api @opentelemetry/sdk-node
+```
+
+```typescript
+import { trace } from '@opentelemetry/api';
+import { OtelAgentTracer } from '@foxframework/otel-agents';
+import { AgentTracer } from '@foxframework/core/agents/telemetry';
+
+// Assumes OTel SDK is already initialised (NodeSDK.start())
+const tracer = new OtelAgentTracer(trace.getTracer('fox-agents', '1.0.0'));
+const tracedAgent = new AgentTracer(myAgent, { tracer });
+
+// All runs now emit OTel spans compatible with Jaeger, Zipkin, OTLP, etc.
+const result = await tracedAgent.run('Summarise the quarterly report.');
 ```

--- a/website/pages/docs/changelog.mdx
+++ b/website/pages/docs/changelog.mdx
@@ -6,6 +6,57 @@ import { Callout } from 'nextra/components'
   Fox Framework sigue [Semantic Versioning](https://semver.org/). El historial completo también está disponible en [CHANGELOG.md](https://github.com/lnavarrocarter/fox-framework/blob/main/CHANGELOG.md) en el repositorio.
 </Callout>
 
+## v1.4.1 — 2026-05-02 (patch)
+
+Fixes críticos de documentación, scripts y configuración de runtime.
+
+- Fix todos los imports `from 'fox-framework'` → `from '@foxframework/core'` en `event-system.mdx`
+- Fix `auth-jwt.mdx` handler `verifyEmail` para usar JWT decode real vía `AuthMiddleware.verifyToken`
+- Corregir paths de scripts `ai:test` y `test:unit` en `package.json`
+- Subir `engines.node` a `>=18.0.0`; añadir `.nvmrc` con Node 18
+- Reescribir snippets en `examples/index.mdx` con APIs reales de express + `@foxframework/core`
+- Añadir clase `OrderRepository` faltante en `database.mdx`
+- Cambiar puerto NotificationService de `3003 → 3004` en `microservices.mdx`
+- Actualizar imagen Docker `consul:latest` → `hashicorp/consul:1.19`
+
+---
+
+## v1.4.0 — 2026-05-01
+
+### Nuevas features
+
+#### Agent Tools Library
+- `CalculatorTool` — evaluador matemático seguro (sin `eval`)
+- `HttpTool` — HTTP requests con `fetch` nativo (GET/POST/PUT/PATCH/DELETE)
+- `FilesystemTool` / `createFilesystemTool` — leer/escribir/listar/borrar archivos con sandbox opcional
+- `JsonPathTool` — navegación de JSON con path expressions (`get`, `keys`, `count`, `flatten`, `pretty`)
+- `createSqlQueryTool` — ejecuta SQL vía cualquier `IQueryExecutor`; modo read-only por defecto
+- `createVectorSearchTool` — búsqueda semántica vía cualquier `IVectorSearchProvider`
+- 44 tests
+
+#### Vector Store Providers
+- `@foxframework/vector-pinecone` — Pinecone REST API (fetch nativo)
+- `@foxframework/vector-weaviate` — Weaviate GraphQL API (fetch nativo)
+- `@foxframework/vector-chroma` — ChromaDB REST API (fetch nativo)
+- Todos implementan `IVectorSearchProvider` con `search`, `upsert`, `delete`
+- 34 tests (34 = 3 × ~11 por package)
+
+#### Agent Streaming SSE
+- `SseStream` — writer SSE de bajo nivel compatible con cualquier `ServerResponse`
+- `AgentSseEmitter` — ejecuta un agente y emite cada step como evento SSE
+- `createAgentSseHandler` — factory de route handler para Express/Fox
+- Eventos: `step`, `done`, `error`, `heartbeat`
+- 21 tests
+
+#### Agent Observability
+- `AgentTracer` — proxy vendor-neutral que añade spans por run y por tool call
+- `ITracer` / `ISpan` interfaces — implementables con cualquier backend
+- `NoOpTracer` / `NoOpSpan` — zero overhead por defecto
+- `@foxframework/otel-agents` — adapter `OtelAgentTracer` para `@opentelemetry/api`
+- 25 tests
+
+---
+
 ## v1.3.0 — 2026-05-01
 
 Esta es la release más grande hasta la fecha. Introduce el **sistema completo de Agentes AI**, tres **model providers** nativos (OpenAI, Anthropic, Ollama), y **adapters serverless** para AWS Lambda, Vercel y GCP.
@@ -74,11 +125,9 @@ Esta es la release más grande hasta la fecha. Introduce el **sistema completo d
 
 ## Roadmap
 
-### v1.4.0 — Planificado
-- **Agent Tools Library** — Tools pre-construidas: HTTP, filesystem, SQL, vector search
-- **Vector Store Integration** — `@foxframework/vector-{pinecone,weaviate,chroma}`
-- **Streaming UI** — Helper SSE para output de agentes en tiempo real
-- **Agent Observability** — Trazas OpenTelemetry por agente run
+### v1.4.2 — En progreso
+- **CLI como workspace** — `packages/cli/` = `@foxframework/cli` con su propio `bin`; extraer `commander`, `inquirer`, `ora` del core
+- **Example Apps** — `basic-api`, `rest-api`, `agent-chat`, `event-sourcing`, `fullstack` con Docker Compose
 
 ### v1.5.0 — Planificado
 - **Workflow Engine** — Workflows duraderos con checkpoint/resume

--- a/website/pages/docs/model-providers.mdx
+++ b/website/pages/docs/model-providers.mdx
@@ -186,3 +186,92 @@ class MyCustomProvider implements IModelProvider {
   }
 }
 ```
+
+---
+
+## Vector Store Providers (v1.4)
+
+Three vector store packages implement `IVectorSearchProvider` for use with `createVectorSearchTool`. All use native `fetch` — no vendor SDKs.
+
+```bash
+npm install @foxframework/vector-pinecone    # Pinecone
+npm install @foxframework/vector-weaviate   # Weaviate
+npm install @foxframework/vector-chroma     # ChromaDB
+```
+
+### Pinecone
+
+```typescript
+import { PineconeProvider } from '@foxframework/vector-pinecone';
+
+const provider = new PineconeProvider({
+  apiKey: process.env.PINECONE_API_KEY!,
+  indexHost: process.env.PINECONE_INDEX_HOST!, // from Pinecone console
+  embed: async (text) => myEmbeddingFn(text),  // optional: auto-embed on search/upsert
+});
+
+// Search
+const results = await provider.search('climate change solutions', { topK: 5 });
+
+// Upsert (requires embed function)
+await provider.upsert('doc-1', 'Fox Framework is a TypeScript web framework.', {
+  source: 'docs',
+  version: '1.4',
+});
+```
+
+### Weaviate
+
+```typescript
+import { WeaviateProvider } from '@foxframework/vector-weaviate';
+
+const provider = new WeaviateProvider({
+  url: 'https://my-cluster.weaviate.network',
+  className: 'Document',          // Weaviate class/collection
+  apiKey: process.env.WEAVIATE_API_KEY,
+  textProperty: 'text',           // property holding document content (default: 'text')
+});
+
+const results = await provider.search('renewable energy', { topK: 3, minScore: 0.7 });
+```
+
+### ChromaDB
+
+```typescript
+import { ChromaProvider } from '@foxframework/vector-chroma';
+
+const provider = new ChromaProvider({
+  url: 'http://localhost:8000',
+  collection: 'my-docs',
+  embed: async (texts) => myBatchEmbedFn(texts), // required for search + upsert
+});
+
+const results = await provider.search('Fox Framework routing', { topK: 5 });
+```
+
+### Comparison
+
+| Feature | Pinecone | Weaviate | ChromaDB |
+|---|---|---|---|
+| Hosting | Cloud (managed) | Cloud + self-hosted | Self-hosted |
+| Embedding | Client-side (optional) | Server-side or client | Client-side (required) |
+| Filter | ✅ metadata filter | ✅ `where` clause | ✅ `where` filter |
+| Namespaces | ✅ | ✅ (via `className`) | ✅ (via `collection`) |
+| Upsert / Delete | ✅ | ✅ | ✅ |
+| SDK dependency | ❌ (fetch) | ❌ (fetch) | ❌ (fetch) |
+
+### Use with an agent
+
+```typescript
+import { createVectorSearchTool } from '@foxframework/core/agents/tools';
+import { PineconeProvider } from '@foxframework/vector-pinecone';
+import { ReActAgent } from '@foxframework/core/agents';
+
+const tool = createVectorSearchTool(
+  new PineconeProvider({ apiKey: '...', indexHost: '...' }),
+  { label: 'knowledge_base', defaultTopK: 5 },
+);
+
+const agent = new ReActAgent({ model, tools: [tool] });
+const result = await agent.run('What does Fox Framework say about middleware?');
+```


### PR DESCRIPTION
## Summary

Documents all v1.4 additions that shipped in code but had no corresponding docs:

- **`agents.mdx`**: 6 built-in tools (`CalculatorTool`, `HttpTool`, `FilesystemTool`, `JsonPathTool`, `createSqlQueryTool`, `createVectorSearchTool`), SSE Streaming (`SseStream`, `AgentSseEmitter`, `createAgentSseHandler` + client-side consumption example), and Telemetry (`AgentTracer`, `ITracer` interface, `OtelAgentTracer` via `@foxframework/otel-agents`)
- **`model-providers.mdx`**: Vector Store Providers section — Pinecone, Weaviate, ChromaDB — with config examples, feature comparison table, and agent integration snippet
- **`changelog.mdx`**: v1.4.0 and v1.4.1 release entries; roadmap updated (v1.4.0 shipped, next is v1.4.2)
- **`_meta.json`**: AI section label bumped to v1.4

All code examples are derived directly from the implementation source.