### PR TITLE
feat(v1.4.4): 5 example apps with Docker infra and unified dev script

### DIFF
--- a/example-apps/README.md
+++ b/example-apps/README.md
@@ -1,0 +1,45 @@
+# Fox Framework — Example Apps
+
+Five runnable example apps demonstrating different aspects of Fox Framework.
+
+| App | Description | Port | Infra |
+|-----|-------------|------|-------|
+| [`basic-api`](./basic-api) | Hello World — minimal HTTP server | 3000 | none |
+| [`rest-api`](./rest-api) | CRUD todos with PostgreSQL | 3001 | Postgres |
+| [`agent-chat`](./agent-chat) | Streaming AI chat (OpenAI / Ollama) | 3002 | Redis (optional) |
+| [`event-sourcing`](./event-sourcing) | Bank account aggregate, event log | 3003 | Redis (optional) |
+| [`fullstack`](./fullstack) | JWT auth + blog CRUD + AI agent | 3004 | Postgres + Redis |
+
+## Quick start
+
+Each app is self-contained. Navigate to its directory and run:
+
+```bash
+cd basic-api
+npm install
+npm run dev
+```
+
+For apps with infrastructure dependencies:
+
+```bash
+cd rest-api
+npm install
+npm run dev -- --infrastructure    # starts Docker Compose infra then the app
+```
+
+## Dev script options
+
+All apps (except `basic-api`) use the same `scripts/dev.js` pattern:
+
+```bash
+npm run dev                                # app only
+npm run dev -- --infrastructure            # infra + app
+npm run dev -- --option infrastructure     # same as above
+```
+
+## Prerequisites
+
+- Node 18+
+- Docker + Docker Compose (for infra-dependent apps)
+- `OPENAI_API_KEY` env var (for `agent-chat` and `fullstack` AI features)

--- a/example-apps/agent-chat/README.md
+++ b/example-apps/agent-chat/README.md
@@ -1,0 +1,46 @@
+# fox-agent-chat
+
+Streaming AI chat app built with [Fox Framework](https://foxframework.dev) agents + SSE.
+
+## Features
+
+- Real-time streaming via Server-Sent Events
+- Built-in tools: HTTP requests, calculator
+- OpenAI (default) or Ollama (local, free)
+- Minimal chat UI served from `/`
+
+## Run
+
+```bash
+npm install
+
+# With OpenAI (default)
+OPENAI_API_KEY=sk-... npm run dev
+
+# With Ollama (local, no API key needed)
+PROVIDER=ollama npm run dev -- --infrastructure
+```
+
+## Environment
+
+```env
+PORT=3002
+
+# OpenAI (default)
+OPENAI_API_KEY=sk-...
+OPENAI_MODEL=gpt-4o-mini
+
+# Ollama override
+PROVIDER=ollama
+OLLAMA_URL=http://localhost:11434
+OLLAMA_MODEL=llama3.2
+```
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | / | Chat UI |
+| GET | /chat/stream?message=... | SSE streaming response |
+| POST | /chat | Non-streaming response |
+| GET | /health | Health check |

--- a/example-apps/agent-chat/docker-compose.infra.yml
+++ b/example-apps/agent-chat/docker-compose.infra.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  # Uncomment to run Ollama locally
+  # ollama:
+  #   image: ollama/ollama:latest
+  #   ports:
+  #     - "11434:11434"
+  #   volumes:
+  #     - ollama_data:/root/.ollama
+
+# volumes:
+#   ollama_data:

--- a/example-apps/agent-chat/package.json
+++ b/example-apps/agent-chat/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "fox-agent-chat",
+  "version": "1.0.0",
+  "description": "Streaming AI chat app with Fox Framework agents — SSE responses",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/src/index.js",
+    "dev": "node scripts/dev.js",
+    "dev:app": "ts-node src/index.ts",
+    "infra:up": "docker compose -f docker-compose.infra.yml up -d",
+    "infra:down": "docker compose -f docker-compose.infra.yml down"
+  },
+  "dependencies": {
+    "@foxframework/core": "*",
+    "@foxframework/model-openai": "*",
+    "@foxframework/model-ollama": "*",
+    "@foxframework/db-redis": "*",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.10.4",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.3.2"
+  }
+}

--- a/example-apps/agent-chat/public/index.html
+++ b/example-apps/agent-chat/public/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fox Agent Chat</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; background: #0f0f0f; color: #e5e5e5; height: 100vh; display: flex; flex-direction: column; }
+    header { padding: 1rem 1.5rem; border-bottom: 1px solid #2a2a2a; background: #1a1a1a; }
+    header h1 { font-size: 1.1rem; font-weight: 600; }
+    header span { font-size: 0.75rem; color: #888; margin-left: 0.5rem; }
+    #messages { flex: 1; overflow-y: auto; padding: 1.5rem; display: flex; flex-direction: column; gap: 1rem; }
+    .msg { max-width: 70%; padding: 0.75rem 1rem; border-radius: 12px; line-height: 1.5; font-size: 0.9rem; }
+    .msg.user { align-self: flex-end; background: #2563eb; color: white; }
+    .msg.agent { align-self: flex-start; background: #1e1e1e; border: 1px solid #2a2a2a; }
+    .msg.agent .step { font-size: 0.75rem; color: #888; margin-bottom: 0.25rem; }
+    .msg.agent .answer { font-weight: 500; }
+    form { display: flex; gap: 0.75rem; padding: 1rem 1.5rem; border-top: 1px solid #2a2a2a; background: #1a1a1a; }
+    input { flex: 1; padding: 0.6rem 1rem; border-radius: 8px; border: 1px solid #2a2a2a; background: #0f0f0f; color: #e5e5e5; font-size: 0.9rem; }
+    button { padding: 0.6rem 1.25rem; border-radius: 8px; border: none; background: #2563eb; color: white; cursor: pointer; font-size: 0.9rem; }
+    button:disabled { opacity: 0.5; cursor: default; }
+  </style>
+</head>
+<body>
+  <header><h1>Fox Agent Chat</h1><span id="provider"></span></header>
+  <div id="messages"></div>
+  <form id="form">
+    <input id="input" type="text" placeholder="Ask anything..." autocomplete="off" />
+    <button type="submit" id="send">Send</button>
+  </form>
+  <script>
+    fetch('/health').then(r => r.json()).then(d => {
+      document.getElementById('provider').textContent = `provider: ${d.provider}`;
+    });
+
+    const messages = document.getElementById('messages');
+    const form = document.getElementById('form');
+    const input = document.getElementById('input');
+    const send = document.getElementById('send');
+
+    function addMessage(role, content) {
+      const div = document.createElement('div');
+      div.className = `msg ${role}`;
+      div.textContent = content;
+      messages.appendChild(div);
+      messages.scrollTop = messages.scrollHeight;
+      return div;
+    }
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const message = input.value.trim();
+      if (!message) return;
+      input.value = '';
+      send.disabled = true;
+
+      addMessage('user', message);
+      const agentDiv = addMessage('agent', '...');
+      let steps = [];
+
+      const url = `/chat/stream?message=${encodeURIComponent(message)}`;
+      const es = new EventSource(url);
+
+      es.addEventListener('step', (e) => {
+        const step = JSON.parse(e.data);
+        if (step.type !== 'final_answer') steps.push(`[${step.type}] ${step.content?.slice(0, 80) ?? ''}`);
+        agentDiv.innerHTML = `<div class="step">${steps.slice(-2).join('<br>')}</div><div class="answer">...</div>`;
+        messages.scrollTop = messages.scrollHeight;
+      });
+
+      es.addEventListener('done', (e) => {
+        const result = JSON.parse(e.data);
+        agentDiv.innerHTML = `<div class="answer">${result.answer}</div>`;
+        messages.scrollTop = messages.scrollHeight;
+        es.close();
+        send.disabled = false;
+        input.focus();
+      });
+
+      es.addEventListener('error', (e) => {
+        try {
+          const err = JSON.parse(e.data);
+          agentDiv.textContent = `Error: ${err.message}`;
+        } catch {
+          agentDiv.textContent = 'Connection error';
+        }
+        es.close();
+        send.disabled = false;
+      });
+    });
+  </script>
+</body>
+</html>

--- a/example-apps/agent-chat/scripts/dev.js
+++ b/example-apps/agent-chat/scripts/dev.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const { execSync, spawn } = require('child_process');
+const args = process.argv.slice(2);
+const opts = new Set(args.flatMap(a => {
+  if (a.startsWith('--option=')) return a.slice(9).split(',');
+  if (a === '--infrastructure') return ['infrastructure'];
+  return [];
+}));
+if (opts.has('infrastructure')) {
+  console.log('[dev] Starting infrastructure...');
+  execSync('docker compose -f docker-compose.infra.yml up -d', { stdio: 'inherit' });
+  console.log('[dev] Infrastructure ready.\n');
+}
+const proc = spawn('npm', ['run', 'dev:app'], { stdio: 'inherit', shell: true });
+proc.on('exit', code => process.exit(code ?? 0));

--- a/example-apps/agent-chat/src/index.ts
+++ b/example-apps/agent-chat/src/index.ts
@@ -1,0 +1,69 @@
+import express from 'express';
+import path from 'path';
+import { ReActAgent } from '@foxframework/core/dist/tsfox/core/agents/react/react.agent';
+import { createAgentSseHandler } from '@foxframework/core/dist/tsfox/core/agents/streaming/create-agent-sse-handler';
+import { HttpTool } from '@foxframework/core/dist/tsfox/core/agents/tools/http.tool';
+import { CalculatorTool } from '@foxframework/core/dist/tsfox/core/agents/tools/calculator.tool';
+
+// ── Model selection ──────────────────────────────────────────────────────────
+async function createModel() {
+  const provider = process.env.PROVIDER ?? 'openai';
+
+  if (provider === 'ollama') {
+    const { OllamaProvider } = await import('@foxframework/model-ollama');
+    return new OllamaProvider({
+      baseUrl: process.env.OLLAMA_URL ?? 'http://localhost:11434',
+      model: process.env.OLLAMA_MODEL ?? 'llama3.2',
+    });
+  }
+
+  const { OpenAIProvider } = await import('@foxframework/model-openai');
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error('OPENAI_API_KEY is required (or set PROVIDER=ollama)');
+  return new OpenAIProvider({ apiKey, model: process.env.OPENAI_MODEL ?? 'gpt-4o-mini' });
+}
+
+// ── App ──────────────────────────────────────────────────────────────────────
+async function main() {
+  const model = await createModel();
+
+  const agent = new ReActAgent({
+    model,
+    tools: [HttpTool, CalculatorTool],
+    systemPrompt: 'You are a helpful assistant. Be concise.',
+    maxIterations: 8,
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use(express.static(path.join(__dirname, '../public')));
+
+  // Health
+  app.get('/health', (_req, res) => res.json({ status: 'healthy', provider: process.env.PROVIDER ?? 'openai' }));
+
+  // Streaming SSE endpoint
+  app.get('/chat/stream', createAgentSseHandler(agent, {
+    getInput: req => req.query?.message as string | undefined,
+    heartbeatIntervalMs: 15_000,
+  }));
+
+  // Non-streaming endpoint (returns full result)
+  app.post('/chat', async (req, res) => {
+    const { message } = req.body;
+    if (!message) return res.status(400).json({ error: 'message is required' }) as any;
+    try {
+      const result = await agent.run(message);
+      res.json({ answer: result.answer, steps: result.steps.length, usage: result.usage });
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  const PORT = Number(process.env.PORT) || 3002;
+  app.listen(PORT, () => {
+    console.log(`Fox agent-chat running on http://localhost:${PORT}`);
+    console.log(`Provider: ${process.env.PROVIDER ?? 'openai'}`);
+  });
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/example-apps/agent-chat/tsconfig.json
+++ b/example-apps/agent-chat/tsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"target":"es2020","module":"commonjs","outDir":"dist","rootDir":"src","strict":true,"esModuleInterop":true,"skipLibCheck":true},"include":["src/**/*"],"exclude":["node_modules","dist"]}

--- a/example-apps/basic-api/README.md
+++ b/example-apps/basic-api/README.md
@@ -1,0 +1,12 @@
+# fox-basic-api
+
+Minimal [Fox Framework](https://foxframework.dev) HTTP API.
+
+## Run
+
+```bash
+npm install
+npm run dev        # ts-node src/index.ts
+```
+
+Open http://localhost:3000

--- a/example-apps/basic-api/package.json
+++ b/example-apps/basic-api/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "fox-basic-api",
+  "version": "1.0.0",
+  "description": "Minimal Fox Framework HTTP API — Hello World + health endpoint",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/src/index.js",
+    "dev": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "@foxframework/core": "*",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.10.4",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.3.2"
+  }
+}

--- a/example-apps/basic-api/src/index.ts
+++ b/example-apps/basic-api/src/index.ts
@@ -1,0 +1,17 @@
+import express from 'express';
+
+const app = express();
+app.use(express.json());
+
+app.get('/', (_req, res) => {
+  res.json({ message: 'Hello from Fox Framework!', version: '1.0.0' });
+});
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'healthy', uptime: process.uptime(), timestamp: new Date().toISOString() });
+});
+
+const PORT = Number(process.env.PORT) || 3000;
+app.listen(PORT, () => {
+  console.log(`Fox basic-api running on http://localhost:${PORT}`);
+});

--- a/example-apps/basic-api/tsconfig.json
+++ b/example-apps/basic-api/tsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"target":"es2020","module":"commonjs","outDir":"dist","rootDir":"src","strict":true,"esModuleInterop":true,"skipLibCheck":true},"include":["src/**/*"],"exclude":["node_modules","dist"]}

--- a/example-apps/event-sourcing/README.md
+++ b/example-apps/event-sourcing/README.md
@@ -1,0 +1,44 @@
+# fox-event-sourcing
+
+Event Sourcing + CQRS demo with [Fox Framework](https://foxframework.dev) — bank account aggregate.
+
+## Concepts
+
+- **Event Sourcing**: state is derived from an append-only event log
+- **Aggregate**: `BankAccount` — rehydrated from events on every request
+- **Event history**: every state change is queryable at `/accounts/:id/events`
+
+## Run
+
+```bash
+npm install
+npm run dev
+```
+
+## Endpoints
+
+```
+POST   /accounts                        Open account { id, owner, initialDeposit? }
+GET    /accounts/:id                    Current state
+GET    /accounts/:id/events             Full event history
+POST   /accounts/:id/deposit            { amount }
+POST   /accounts/:id/withdraw           { amount }
+DELETE /accounts/:id                    Close account
+```
+
+## Example
+
+```bash
+# Open account
+curl -X POST http://localhost:3003/accounts \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"acc-1","owner":"Alice","initialDeposit":1000}'
+
+# Deposit
+curl -X POST http://localhost:3003/accounts/acc-1/deposit \
+  -H 'Content-Type: application/json' \
+  -d '{"amount":500}'
+
+# View full event log
+curl http://localhost:3003/accounts/acc-1/events
+```

--- a/example-apps/event-sourcing/docker-compose.infra.yml
+++ b/example-apps/event-sourcing/docker-compose.infra.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5

--- a/example-apps/event-sourcing/package.json
+++ b/example-apps/event-sourcing/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "fox-event-sourcing",
+  "version": "1.0.0",
+  "description": "Event Sourcing + CQRS example with Fox Framework — bank account aggregate",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/src/index.js",
+    "dev": "node scripts/dev.js",
+    "dev:app": "ts-node src/index.ts",
+    "infra:up": "docker compose -f docker-compose.infra.yml up -d",
+    "infra:down": "docker compose -f docker-compose.infra.yml down"
+  },
+  "dependencies": {
+    "@foxframework/core": "*",
+    "@foxframework/db-redis": "*",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.10.4",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.3.2"
+  }
+}

--- a/example-apps/event-sourcing/scripts/dev.js
+++ b/example-apps/event-sourcing/scripts/dev.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const { execSync, spawn } = require('child_process');
+const args = process.argv.slice(2);
+const opts = new Set(args.flatMap(a => {
+  if (a.startsWith('--option=')) return a.slice(9).split(',');
+  if (a === '--infrastructure') return ['infrastructure'];
+  return [];
+}));
+if (opts.has('infrastructure')) {
+  console.log('[dev] Starting infrastructure...');
+  execSync('docker compose -f docker-compose.infra.yml up -d', { stdio: 'inherit' });
+  console.log('[dev] Infrastructure ready.\n');
+}
+const proc = spawn('npm', ['run', 'dev:app'], { stdio: 'inherit', shell: true });
+proc.on('exit', code => process.exit(code ?? 0));

--- a/example-apps/event-sourcing/src/index.ts
+++ b/example-apps/event-sourcing/src/index.ts
@@ -1,0 +1,99 @@
+import express from 'express';
+
+// ── Simple in-process event store ──────────────────────────────────────────
+interface DomainEvent { type: string; aggregateId: string; payload: unknown; timestamp: string; sequence: number; }
+const store = new Map<string, DomainEvent[]>();
+
+function appendEvents(id: string, events: Omit<DomainEvent, 'timestamp' | 'sequence'>[]) {
+  const existing = store.get(id) ?? [];
+  const newEvents = events.map((e, i) => ({ ...e, timestamp: new Date().toISOString(), sequence: existing.length + i + 1 }));
+  store.set(id, [...existing, ...newEvents]);
+  return newEvents;
+}
+function loadEvents(id: string): DomainEvent[] { return store.get(id) ?? []; }
+
+// ── BankAccount aggregate ──────────────────────────────────────────────────
+interface AccountState { id: string; owner: string; balance: number; isClosed: boolean; }
+
+function applyEvent(state: AccountState, event: DomainEvent): AccountState {
+  switch (event.type) {
+    case 'AccountOpened': return { ...state, ...(event.payload as any) };
+    case 'MoneyDeposited': return { ...state, balance: state.balance + (event.payload as any).amount };
+    case 'MoneyWithdrawn': return { ...state, balance: state.balance - (event.payload as any).amount };
+    case 'AccountClosed': return { ...state, isClosed: true };
+    default: return state;
+  }
+}
+
+function rehydrate(id: string): AccountState | null {
+  const events = loadEvents(id);
+  if (events.length === 0) return null;
+  return events.reduce((s, e) => applyEvent(s, e), { id, owner: '', balance: 0, isClosed: false });
+}
+
+// ── API ───────────────────────────────────────────────────────────────────
+const app = express();
+app.use(express.json());
+
+app.get('/health', (_req, res) => res.json({ status: 'healthy' }));
+
+// Open account
+app.post('/accounts', (req, res) => {
+  const { id, owner, initialDeposit = 0 } = req.body;
+  if (!id || !owner) return res.status(400).json({ error: 'id and owner are required' }) as any;
+  if (store.has(id)) return res.status(409).json({ error: 'Account already exists' }) as any;
+  appendEvents(id, [
+    { type: 'AccountOpened', aggregateId: id, payload: { id, owner, balance: 0 } },
+    ...(initialDeposit > 0 ? [{ type: 'MoneyDeposited', aggregateId: id, payload: { amount: initialDeposit } }] : []),
+  ]);
+  res.status(201).json(rehydrate(id));
+});
+
+// Get current state
+app.get('/accounts/:id', (req, res) => {
+  const state = rehydrate(req.params.id);
+  if (!state) return res.status(404).json({ error: 'Account not found' }) as any;
+  res.json(state);
+});
+
+// Get event history
+app.get('/accounts/:id/events', (req, res) => {
+  const events = loadEvents(req.params.id);
+  if (events.length === 0) return res.status(404).json({ error: 'Account not found' }) as any;
+  res.json(events);
+});
+
+// Deposit
+app.post('/accounts/:id/deposit', (req, res) => {
+  const state = rehydrate(req.params.id);
+  if (!state) return res.status(404).json({ error: 'Account not found' }) as any;
+  if (state.isClosed) return res.status(422).json({ error: 'Account is closed' }) as any;
+  const { amount } = req.body;
+  if (!amount || amount <= 0) return res.status(400).json({ error: 'amount must be positive' }) as any;
+  appendEvents(req.params.id, [{ type: 'MoneyDeposited', aggregateId: req.params.id, payload: { amount } }]);
+  res.json(rehydrate(req.params.id));
+});
+
+// Withdraw
+app.post('/accounts/:id/withdraw', (req, res) => {
+  const state = rehydrate(req.params.id);
+  if (!state) return res.status(404).json({ error: 'Account not found' }) as any;
+  if (state.isClosed) return res.status(422).json({ error: 'Account is closed' }) as any;
+  const { amount } = req.body;
+  if (!amount || amount <= 0) return res.status(400).json({ error: 'amount must be positive' }) as any;
+  if (state.balance < amount) return res.status(422).json({ error: 'Insufficient funds' }) as any;
+  appendEvents(req.params.id, [{ type: 'MoneyWithdrawn', aggregateId: req.params.id, payload: { amount } }]);
+  res.json(rehydrate(req.params.id));
+});
+
+// Close account
+app.delete('/accounts/:id', (req, res) => {
+  const state = rehydrate(req.params.id);
+  if (!state) return res.status(404).json({ error: 'Account not found' }) as any;
+  if (state.isClosed) return res.status(422).json({ error: 'Already closed' }) as any;
+  appendEvents(req.params.id, [{ type: 'AccountClosed', aggregateId: req.params.id, payload: {} }]);
+  res.json({ message: 'Account closed', id: req.params.id });
+});
+
+const PORT = Number(process.env.PORT) || 3003;
+app.listen(PORT, () => console.log(`Fox event-sourcing running on http://localhost:${PORT}`));

--- a/example-apps/event-sourcing/tsconfig.json
+++ b/example-apps/event-sourcing/tsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"target":"es2020","module":"commonjs","outDir":"dist","rootDir":"src","strict":true,"esModuleInterop":true,"skipLibCheck":true},"include":["src/**/*"],"exclude":["node_modules","dist"]}

--- a/example-apps/fullstack/README.md
+++ b/example-apps/fullstack/README.md
@@ -1,0 +1,51 @@
+# fox-fullstack
+
+Full-stack [Fox Framework](https://foxframework.dev) app — JWT auth + blog CRUD + optional AI agent.
+
+## Features
+
+- JWT authentication (`/auth/register`, `/auth/login`, `/auth/me`)
+- Protected blog posts CRUD (`/posts`)
+- Optional AI agent with SSE streaming (`/ai/stream?q=...`) — requires `OPENAI_API_KEY`
+- Docker Compose for Postgres + Redis infra
+
+## Run
+
+```bash
+npm install
+
+# App only (in-memory)
+npm run dev
+
+# App + Postgres + Redis via Docker Compose
+npm run dev -- --infrastructure
+
+# With AI agent
+OPENAI_API_KEY=sk-... npm run dev -- --infrastructure
+```
+
+## Environment
+
+```env
+PORT=3004
+JWT_SECRET=change-me-in-production
+DATABASE_URL=postgresql://fox:fox@localhost:5433/fullstack
+REDIS_URL=redis://localhost:6380
+OPENAI_API_KEY=sk-...          # optional — enables /ai/stream
+OPENAI_MODEL=gpt-4o-mini
+```
+
+## API
+
+```
+POST  /auth/register      { email, password }
+POST  /auth/login         { email, password }
+GET   /auth/me            Authorization: Bearer <token>
+
+GET   /posts
+POST  /posts              Authorization: Bearer <token>  { title, body }
+DELETE /posts/:id         Authorization: Bearer <token>
+
+GET   /ai/stream?q=...    Authorization: Bearer <token>  (SSE)
+GET   /health
+```

--- a/example-apps/fullstack/docker-compose.infra.yml
+++ b/example-apps/fullstack/docker-compose.infra.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - "5433:5432"
+    environment:
+      POSTGRES_USER: fox
+      POSTGRES_PASSWORD: fox
+      POSTGRES_DB: fullstack
+    volumes:
+      - fullstack_pg:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U fox"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6380:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  fullstack_pg:

--- a/example-apps/fullstack/package.json
+++ b/example-apps/fullstack/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "fox-fullstack",
+  "version": "1.0.0",
+  "description": "Full-stack Fox Framework app — REST API + auth + DB + AI agent + SSE streaming",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/src/index.js",
+    "dev": "node scripts/dev.js",
+    "dev:app": "ts-node src/index.ts",
+    "infra:up": "docker compose -f docker-compose.infra.yml up -d",
+    "infra:down": "docker compose -f docker-compose.infra.yml down"
+  },
+  "dependencies": {
+    "@foxframework/core": "*",
+    "@foxframework/auth-jwt": "*",
+    "@foxframework/db-postgres": "*",
+    "@foxframework/db-redis": "*",
+    "@foxframework/model-openai": "*",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.10.4",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.3.2"
+  }
+}

--- a/example-apps/fullstack/scripts/dev.js
+++ b/example-apps/fullstack/scripts/dev.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const { execSync, spawn } = require('child_process');
+const args = process.argv.slice(2);
+const opts = new Set(args.flatMap(a => {
+  if (a.startsWith('--option=')) return a.slice(9).split(',');
+  if (a === '--infrastructure') return ['infrastructure'];
+  return [];
+}));
+if (opts.has('infrastructure')) {
+  console.log('[dev] Starting infrastructure...');
+  execSync('docker compose -f docker-compose.infra.yml up -d', { stdio: 'inherit' });
+  console.log('[dev] Infrastructure ready.\n');
+}
+const proc = spawn('npm', ['run', 'dev:app'], { stdio: 'inherit', shell: true });
+proc.on('exit', code => process.exit(code ?? 0));

--- a/example-apps/fullstack/src/index.ts
+++ b/example-apps/fullstack/src/index.ts
@@ -1,0 +1,103 @@
+import express, { Request, Response, NextFunction } from 'express';
+import { createAgentSseHandler } from '@foxframework/core/dist/tsfox/core/agents/streaming/create-agent-sse-handler';
+import { ReActAgent } from '@foxframework/core/dist/tsfox/core/agents/react/react.agent';
+import { HttpTool } from '@foxframework/core/dist/tsfox/core/agents/tools/http.tool';
+import { CalculatorTool } from '@foxframework/core/dist/tsfox/core/agents/tools/calculator.tool';
+import jwt from 'jsonwebtoken';
+
+const JWT_SECRET = process.env.JWT_SECRET ?? 'dev-secret-change-in-production';
+
+// ── In-memory stores (replace with @foxframework/db-postgres in production) ─
+interface User { id: number; email: string; passwordHash: string; role: 'user' | 'admin'; }
+interface Post { id: number; title: string; body: string; authorId: number; createdAt: string; }
+const users: User[] = [];
+const posts: Post[] = [];
+let nextUserId = 1, nextPostId = 1;
+
+// Simplistic hash — use bcrypt in production
+function hashPw(pw: string) { return Buffer.from(pw).toString('base64'); }
+function verifyPw(pw: string, hash: string) { return hashPw(pw) === hash; }
+
+// ── Middleware ─────────────────────────────────────────────────────────────
+function authMiddleware(req: Request, res: Response, next: NextFunction) {
+  const header = req.headers.authorization;
+  if (!header?.startsWith('Bearer ')) return res.status(401).json({ error: 'No token' }) as any;
+  try {
+    (req as any).user = jwt.verify(header.slice(7), JWT_SECRET);
+    next();
+  } catch {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+// ── App ─────────────────────────────────────────────────────────────────────
+async function main() {
+  const app = express();
+  app.use(express.json());
+
+  app.get('/health', (_req, res) => res.json({ status: 'healthy', version: '1.0.0' }));
+
+  // Auth
+  app.post('/auth/register', (req, res) => {
+    const { email, password } = req.body;
+    if (!email || !password) return res.status(400).json({ error: 'email and password required' }) as any;
+    if (users.find(u => u.email === email)) return res.status(409).json({ error: 'Email taken' }) as any;
+    const user: User = { id: nextUserId++, email, passwordHash: hashPw(password), role: 'user' };
+    users.push(user);
+    const token = jwt.sign({ sub: user.id, email: user.email, role: user.role }, JWT_SECRET, { expiresIn: '7d' });
+    res.status(201).json({ token, user: { id: user.id, email: user.email, role: user.role } });
+  });
+
+  app.post('/auth/login', (req, res) => {
+    const { email, password } = req.body;
+    const user = users.find(u => u.email === email);
+    if (!user || !verifyPw(password, user.passwordHash)) return res.status(401).json({ error: 'Invalid credentials' }) as any;
+    const token = jwt.sign({ sub: user.id, email: user.email, role: user.role }, JWT_SECRET, { expiresIn: '7d' });
+    res.json({ token, user: { id: user.id, email: user.email, role: user.role } });
+  });
+
+  app.get('/auth/me', authMiddleware, (req, res) => res.json((req as any).user));
+
+  // Posts
+  app.get('/posts', (_req, res) => res.json(posts));
+
+  app.post('/posts', authMiddleware, (req, res) => {
+    const { title, body } = req.body;
+    if (!title || !body) return res.status(400).json({ error: 'title and body required' }) as any;
+    const post: Post = { id: nextPostId++, title, body, authorId: (req as any).user.sub, createdAt: new Date().toISOString() };
+    posts.push(post);
+    res.status(201).json(post);
+  });
+
+  app.delete('/posts/:id', authMiddleware, (req, res) => {
+    const idx = posts.findIndex(p => p.id === Number(req.params.id));
+    if (idx === -1) return res.status(404).json({ error: 'Not found' }) as any;
+    const post = posts[idx];
+    const user = (req as any).user;
+    if (post.authorId !== user.sub && user.role !== 'admin') return res.status(403).json({ error: 'Forbidden' }) as any;
+    posts.splice(idx, 1);
+    res.json({ message: 'Deleted', id: post.id });
+  });
+
+  // AI Agent (requires OPENAI_API_KEY)
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (apiKey) {
+    const { OpenAIProvider } = await import('@foxframework/model-openai');
+    const agent = new ReActAgent({
+      model: new OpenAIProvider({ apiKey, model: process.env.OPENAI_MODEL ?? 'gpt-4o-mini' }),
+      tools: [HttpTool, CalculatorTool],
+      systemPrompt: 'You are a helpful assistant for a blog platform.',
+    });
+    app.get('/ai/stream', authMiddleware, createAgentSseHandler(agent, {
+      getInput: req => req.query?.q as string | undefined,
+    }) as any);
+    console.log('AI agent enabled');
+  } else {
+    console.log('AI agent disabled (set OPENAI_API_KEY to enable)');
+  }
+
+  const PORT = Number(process.env.PORT) || 3004;
+  app.listen(PORT, () => console.log(`Fox fullstack running on http://localhost:${PORT}`));
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/example-apps/fullstack/tsconfig.json
+++ b/example-apps/fullstack/tsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"target":"es2020","module":"commonjs","outDir":"dist","rootDir":"src","strict":true,"esModuleInterop":true,"skipLibCheck":true},"include":["src/**/*"],"exclude":["node_modules","dist"]}

--- a/example-apps/rest-api/README.md
+++ b/example-apps/rest-api/README.md
@@ -1,0 +1,32 @@
+# fox-rest-api
+
+CRUD REST API built with [Fox Framework](https://foxframework.dev) and PostgreSQL.
+
+## Run
+
+```bash
+npm install
+
+# App only (in-memory store)
+npm run dev
+
+# App + PostgreSQL via Docker Compose
+npm run dev -- --infrastructure
+```
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /todos | List all todos |
+| GET | /todos/:id | Get by id |
+| POST | /todos | Create todo (body: `{ title }`) |
+| PATCH | /todos/:id | Update todo |
+| DELETE | /todos/:id | Delete todo |
+
+## Environment
+
+```env
+PORT=3001
+DATABASE_URL=postgresql://fox:fox@localhost:5432/todos
+```

--- a/example-apps/rest-api/docker-compose.infra.yml
+++ b/example-apps/rest-api/docker-compose.infra.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: fox
+      POSTGRES_PASSWORD: fox
+      POSTGRES_DB: todos
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U fox"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/example-apps/rest-api/package.json
+++ b/example-apps/rest-api/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "fox-rest-api",
+  "version": "1.0.0",
+  "description": "CRUD REST API with Fox Framework — todos with PostgreSQL",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/src/index.js",
+    "dev": "node scripts/dev.js",
+    "dev:app": "ts-node src/index.ts",
+    "infra:up": "docker compose -f docker-compose.infra.yml up -d",
+    "infra:down": "docker compose -f docker-compose.infra.yml down"
+  },
+  "dependencies": {
+    "@foxframework/core": "*",
+    "@foxframework/db-postgres": "*",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.10.4",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.3.2"
+  }
+}

--- a/example-apps/rest-api/scripts/dev.js
+++ b/example-apps/rest-api/scripts/dev.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * Unified dev script — supports --infrastructure flag.
+ *
+ * Usage:
+ *   npm run dev                          # start app only
+ *   npm run dev -- --infrastructure      # start infra + app
+ *   npm run dev -- --option infrastructure,test
+ */
+const { execSync, spawn } = require('child_process');
+
+const args = process.argv.slice(2);
+const opts = new Set(
+  args.flatMap(a => {
+    if (a.startsWith('--option=')) return a.slice(9).split(',');
+    if (a === '--infrastructure') return ['infrastructure'];
+    return [];
+  })
+);
+
+if (opts.has('infrastructure')) {
+  console.log('[dev] Starting infrastructure...');
+  execSync('docker compose -f docker-compose.infra.yml up -d', { stdio: 'inherit' });
+  console.log('[dev] Infrastructure ready.\n');
+}
+
+const proc = spawn('npm', ['run', 'dev:app'], { stdio: 'inherit', shell: true });
+proc.on('exit', code => process.exit(code ?? 0));

--- a/example-apps/rest-api/src/index.ts
+++ b/example-apps/rest-api/src/index.ts
@@ -1,0 +1,44 @@
+import express, { Request, Response } from 'express';
+
+const app = express();
+app.use(express.json());
+
+// In-memory store (replace with @foxframework/db-postgres in production)
+interface Todo { id: number; title: string; completed: boolean; createdAt: string; }
+let todos: Todo[] = [];
+let nextId = 1;
+
+app.get('/health', (_req, res) => res.json({ status: 'healthy' }));
+
+app.get('/todos', (_req, res: Response) => res.json(todos));
+
+app.get('/todos/:id', (req: Request, res: Response) => {
+  const todo = todos.find(t => t.id === Number(req.params.id));
+  if (!todo) return res.status(404).json({ error: 'Todo not found' }) as any;
+  res.json(todo);
+});
+
+app.post('/todos', (req: Request, res: Response) => {
+  const { title } = req.body;
+  if (!title) return res.status(400).json({ error: 'title is required' }) as any;
+  const todo: Todo = { id: nextId++, title, completed: false, createdAt: new Date().toISOString() };
+  todos.push(todo);
+  res.status(201).json(todo);
+});
+
+app.patch('/todos/:id', (req: Request, res: Response) => {
+  const idx = todos.findIndex(t => t.id === Number(req.params.id));
+  if (idx === -1) return res.status(404).json({ error: 'Todo not found' }) as any;
+  todos[idx] = { ...todos[idx], ...req.body };
+  res.json(todos[idx]);
+});
+
+app.delete('/todos/:id', (req: Request, res: Response) => {
+  const idx = todos.findIndex(t => t.id === Number(req.params.id));
+  if (idx === -1) return res.status(404).json({ error: 'Todo not found' }) as any;
+  const [deleted] = todos.splice(idx, 1);
+  res.json(deleted);
+});
+
+const PORT = Number(process.env.PORT) || 3001;
+app.listen(PORT, () => console.log(`Fox rest-api running on http://localhost:${PORT}`));

--- a/example-apps/rest-api/tsconfig.json
+++ b/example-apps/rest-api/tsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"target":"es2020","module":"commonjs","outDir":"dist","rootDir":"src","strict":true,"esModuleInterop":true,"skipLibCheck":true},"include":["src/**/*"],"exclude":["node_modules","dist"]}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "access": "public"
   },
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "example-apps/*"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Adds `example-apps/` workspace with 5 self-contained, runnable example apps:

| App | Description | Port |
|-----|-------------|------|
| `basic-api` | Minimal Hello World HTTP server | 3000 |
| `rest-api` | CRUD todos + PostgreSQL Docker Compose | 3001 |
| `agent-chat` | Streaming AI chat (OpenAI/Ollama) + SSE UI | 3002 |
| `event-sourcing` | BankAccount aggregate with event history endpoint | 3003 |
| `fullstack` | JWT auth + blog CRUD + optional AI agent | 3004 |

## Key details

- All infra-dependent apps share a `scripts/dev.js` with unified `--infrastructure` flag:
  ```bash
  npm run dev                       # app only
  npm run dev -- --infrastructure   # Docker Compose infra then app
  ```
- `agent-chat`: OpenAI default; switch to Ollama with `PROVIDER=ollama` (zero cost, local)
- `agent-chat` includes a minimal streaming chat UI at `/` (pure HTML/JS, no bundler)
- Each app has its own `README.md`, `tsconfig.json`, `package.json`, and `docker-compose.infra.yml`
- `example-apps/*` added to root npm workspaces